### PR TITLE
Update to xcm docs

### DIFF
--- a/docs/xcm/building-with-xcm/create-xc20-assets.md
+++ b/docs/xcm/building-with-xcm/create-xc20-assets.md
@@ -64,22 +64,22 @@ To set the asset metadata, click on **Developer** at the top of the page and the
 
 You can use the **Extrinsics** page to perform other functions such as minting tokens, delegating a team, freeze and thaw assets or accounts, and more.
 
-## Generate Mintable XC20 Precompile Address
+## Generate XC20 Precompile Address
 
-The use our asset now as XC20 on MetaMask or another EVM wallet we need to generate the smart contract. The mintable XC20 precompile address is generated using the following:
+The use our asset now as XC20 on MetaMask or another EVM wallet we need to generate the smart contract. The XC20 precompile address is generated using the following rule:
 
-`address = "0xFFFFFFFF..." + DecimalToHex(AssetId)`
+`address = "0xFFFFFFFF" + DecimalToHexWith32Digits(AssetId)`
 
 The first step is to take the asset ID and convert it to a hex value. You can use your search engine of choice to look up a simple tool for converting decimals to hex values. In this tutorial, we will use [this decimal to hexadecimal converter](https://www.rapidtables.com/convert/number/decimal-to-hex.html).
 
 For asset ID `19992021`, the hex value is `1310DD5`.
 
-Mintable XC20 precompiles can only fall between  `0xFFFFFFFF00000000000000000000000000000000` and `0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF`. As such, the first 8 characters of the address will always be `FFFFFFFF`. Since Ethereum addresses are 40 characters long, you will need to prepend 0s to the hex value until the address has 40 characters.
+XC20 precompiles can only fall between  `0xFFFFFFFF00000000000000000000000000000000` and `0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF`. As such, the first 8 characters of the address will always be `FFFFFFFF`. Since Ethereum addresses are 40 characters long, you will need to prepend 0s to the hex value until the address has 40 characters.
 
 The hex value that was already generated in the example is 7 characters long, so prepending the first 8 characters, `FFFFFFFF`, to the hex value will give you the part of the 40-character address you need to interact with the XC20 precompile. Note that you still need to add zeros to get the 40-character address. You add the zeros between `FFFFFFFF` and generated hex.
 
 For this example, the full address is `0xFFFFFFFF00000000000000000000000001310dD5`.
 
-Now that you've generated the mintable XC20 precompile address, you can use the address to interact with the XC20 as you would with any other ERC20 in Remix.
+Now that you've generated the XC20 precompile address, you can use the address to interact with the XC20 as you would with any other ERC20 in Remix.
 
 [polkadotjs-apps]: https://polkadot.js.org/apps/

--- a/docs/xcm/building-with-xcm/faq-for-smart-contracts.md
+++ b/docs/xcm/building-with-xcm/faq-for-smart-contracts.md
@@ -6,8 +6,9 @@ sidebar_position: 6
 
 ## Q: Unable to use `transferFrom` for XC20 (DOT, KSM...) in Solidity contract
 
-An EVM smart contract (using XC20) also needs native token (ASTR, SDN, SBY) balance. In order for a contract to accept native tokens the contract needs payable function.
+This was an issue before when an account had to hold some native currency in order to be eligible to receive foreign currency.
+Since this was causing problems for our users, it was changed and no is no longer a requirement for payable foreign assets.
 
-```solidity
-function () public payable {}
-```
+Please note that for custom assets, which aren't supported as payment asset by Astar or Shiden, account (or contract) still has
+to hold at least ED in native currency to be eligible to receive custom asset.
+

--- a/docs/xcm/integration/tools.md
+++ b/docs/xcm/integration/tools.md
@@ -26,7 +26,21 @@ xcm-tools parachain-account 2006
 Replace **2006** with the parachain Id you require.
 
 For calculating sibling parachain's sovereign account, use the following command:
-> xcm-tools parachain-account -s 2006
+```bash
+xcm-tools parachain-account -s 2006
 5Eg2fntKDrAxhaGuB3idrxCFu3BveuyB1MooVPYuj2jaoSsw
+```
+
 E.g. this will be sovereign account of Astar on Statemint.
 Replace 2006 with the parachain Id you require.
+
+## XC20 Address
+
+For calculating XC20 EVM address, use the following command:
+```bash
+xcm-tools asset-id 42424242424242
+pallet_assets: 42424242424242
+EVM XC20: 0xffffffff000000000000000000002695a9e649b2
+```
+
+You can input standard asset Id (as seen by pallet-assets) and as output you get H160 address of that asset.

--- a/docs/xcm/using-xcm/xcm-transactions.md
+++ b/docs/xcm/using-xcm/xcm-transactions.md
@@ -4,20 +4,9 @@ sidebar_position: 1
 
 # XCM Transactions
 
-## Overview
+The following chapters will describe how to transfer native and foreign assets using Astar portal.
 
-**XCM is a format for how message transfer should be performed in an interoperable network.  Cross-Consensus Messaging is between chains, smart contracts, pallets, bridges, and even sharded enclaves like SPREE.**
-
-The significance of XCM is attributed to the groundbreaking capability of DOT, Polkadot's native coin, to be traded, sent, and composed across all parachains on the Polkadot network, the same as KSM will be for Kusama.
-The instruction here will explain how you will be able to transfer DOT via XCM on the Astar Portal from Polkadot to Astar. The same instructions can be used for KSM on Shiden.
-
-Also, HRMP is something that’s coming really soon. Currently, you have the ability to transfer DOT as the first asset but when HRMP becomes available in the next few weeks, it will be any token.
-
-One of the biggest takeaways for you today is that XCM is a generic message format designed to be a language for communication between two systems. As the name suggests, it’s not necessarily only bound to Substrate-based or Dotsama chains - it can be adopted and used by any system using any consensus.
-
-## Instructions
-
-### XCM Transfer from Polkadot to Astar
+## XCM Transfer from Polkadot to Astar
 
 When you go to the [Assets](https://portal.astar.network/#/assets) page, you can see the XCM Assets panel.
 


### PR DESCRIPTION
* removed `Overview` from XCM transactions since it was incorrect and already covered in super-page
* fixed XCM tools and added missing `XC20 address` block
* removed `mintable` word from XC20 asset creation