### PR TITLE
Improved XCM remote transact documentation

### DIFF
--- a/docs/xcm/building-with-xcm/xc-remote-transact.md
+++ b/docs/xcm/building-with-xcm/xc-remote-transact.md
@@ -69,6 +69,13 @@ For example, let's assume `Alice` is sending an XCM sequence from `Polkadot` to 
 
 Please use `xcm-tools` binary to generate the derived addresse based on your needs.
 
+:::caution
+Please be aware that it is possible derived accounts will change with the introduction of **XCM v3**.
+This is because `AccountId32` type's `network` parameter will become an `Option<NetworkId>`.
+
+**XCM v3** is still under development so whether this will happen still remains uncertain.
+:::
+
 ## Remote Transact via EVM Smart Contracts
 
 We enable EVM smart contracts to send `Transact` instructions to remote chains, given them the possiblity to execute arbitrary calls.
@@ -91,7 +98,7 @@ To simplify the API via which EVM smart contracts send the `Transact` instructio
 
 There are no refunds at the end of sequence. Unused weight will be handled by the remote chain.
 
-## API
+### Precompiles API
 
 `Transact` functionality is exposed to EVM smart contracts via precompiles. Interface can be found [here](https://github.com/AstarNetwork/astar-frame) under the XCM precompiles.
 
@@ -113,7 +120,7 @@ function remote_transact(
 
 Please read on to get a better understanding of how to calculate these parameters.
 
-## Payment Asset and Transact Weight
+### Payment Asset and Transact Weight
 
 Specifying the correct amount of assets to withdraw and buy execution time with, as well as the correct transact weight can be tricky. Neither are actually controlled by `Astar` or `Shiden` runtime, instead the destination chain's runtime handles it. There are a few points and tips that can help user calculate the correct values.
 

--- a/docs/xcm/building-with-xcm/xc-remote-transact.md
+++ b/docs/xcm/building-with-xcm/xc-remote-transact.md
@@ -6,7 +6,7 @@ sidebar_position: 6
 
 ## Feature Overview
 
-XCM's `Transact` instructions allows the sender to execute arbitrary calls in the destination chain. This feature is extremely useful since it allows us to control our account on a remote chain.
+XCM's `Transact` instruction allows the sender to execute arbitrary calls in the destination chain. This feature is extremely useful since it allows us to control our account on a remote chain.
 
 For example, a user could send `Transact` instruction from **Astar** to **Polkadot** that will transfer some `DOT` from user's derived account on **Polkadot** to an arbitrary receiver account on **Polkadot**. The end user doesn't directly interact with **Polkadot** chain, but can still change its state. It's important to note that this is just an example - any call that can be interpreted by the remote (destination) chain can potentially be sent and executed.
 

--- a/docs/xcm/building-with-xcm/xc-remote-transact.md
+++ b/docs/xcm/building-with-xcm/xc-remote-transact.md
@@ -88,7 +88,19 @@ To simplify the API via which EVM smart contracts send the `Transact` instructio
 3. `BuyExecution`
 4. `Transact`
 
-`DescendOrigin` will ensure that the origin is correctly set to be the smart contract's derived SS58 address. **TODO** give an example?
+`DescendOrigin` will ensure that the origin is correctly set to be the smart contract's derived SS58 address.
+
+For example, let's assume you have a contract deployed on Shibuya and are calling the XCM precompile `remote_transact` with the intention of sending an XCM sequence to a sibling parachain. This sibling parachain uses the same address derivation as do our runtimes. The address derivation path will be like this:
+
+| Name | Address |
+| ---- | ------- |
+| Contract H160 Address | `0x48DD0a20a199f96B56eCE7e994D83614A148aA63` |
+| Contract Derived SS58 Address | `agn53DdEuRgQsvgxqj5M1AecxB6LpbXT7T1R1hjVcoEBR6M` |
+| SS58 Address Public Key | `0xd219fe1b02545c7dd7e718b1530b4e32b23288351f61e5975c7dc49b004ff119` |
+| Caller Multilocation | `{ parents: 1, interior: X2 ( Parachain(2000), AccountId32 {network: NetworkId::Any, id: 0xd219f...f119 } ) }` |
+| Derived Account32Hash Address | `5FrhDFydxUwbWyXT1XDBhRUUYpQtiJJ6skB6n2XV4NubC9fP` |
+
+This means that the following instructions like `WithdrawAsset` and `Transact` will be executed as if origin was address `5FrhDFydxUwbWyXT1XDBhRUUYpQtiJJ6skB6n2XV4NubC9fP`.
 
 `WithdrawAsset` at the moment requires that asset representation is present in our runtimes. However, it is expected that the remote chain's derived address will be funded so it can pay for XCM execution.
 
@@ -97,6 +109,20 @@ To simplify the API via which EVM smart contracts send the `Transact` instructio
 `Transact` will execute the encoded call. The `origin_type` is set to `SovereignAccount` and cannot be changed by the end user.
 
 There are no refunds at the end of sequence. Unused weight will be handled by the remote chain.
+
+### Remote Derived Contract Address
+
+For example, let's assume you have a contract deployed on Shibuya and are calling the XCM precompile `remote_transact` with the intention of sending an XCM sequence to a **sibling parachain**. This sibling parachain uses the same address derivation as do our runtimes (described above). The address derivation path will be like this:
+
+| Name | Address |
+| ---- | ------- |
+| Contract H160 Address | `0x48DD0a20a199f96B56eCE7e994D83614A148aA63` |
+| Contract Derived SS58 Address | `agn53DdEuRgQsvgxqj5M1AecxB6LpbXT7T1R1hjVcoEBR6M` |
+| SS58 Address Public Key | `0xd219fe1b02545c7dd7e718b1530b4e32b23288351f61e5975c7dc49b004ff119` |
+| Caller Multilocation | `{ parents: 1, interior: X2 ( Parachain(2000), AccountId32 {network: NetworkId::Any, id: 0xd219f...f119 } ) }` |
+| Derived Account32Hash Address | `5FrhDFydxUwbWyXT1XDBhRUUYpQtiJJ6skB6n2XV4NubC9fP` |
+
+This means that the instructions like `WithdrawAsset` and `Transact` will be executed on remote chain as if origin was the address `5FrhDFydxUwbWyXT1XDBhRUUYpQtiJJ6skB6n2XV4NubC9fP`.
 
 ### Precompiles API
 


### PR DESCRIPTION
Modified (and hopefully improved) remote transact documentation.
Added additional examples and sequence description.

Initially intended to add WASM SC remote call example but decided to make it a separate page.