### PR TITLE
Fix mistake on "Building Your Collator" page.

### DIFF
--- a/docs/nodes/collator/secure_setup_guide/building_node.md
+++ b/docs/nodes/collator/secure_setup_guide/building_node.md
@@ -76,7 +76,7 @@ The easiest way to install an Astar node is to download the binaries. You can fi
 Get the file and extract:
 
 ```
-wget $(curl -s https://api.github.com/repos/AstarNetwork/Astar/releases/latest | grep "tag_name" | awk '{print "https://github.com/AstarNetwork/Astar/releases/download/" substr($2, 2, length($2)-3) "/astar-collator-" substr($2, 3, length($2)-4) "-ubuntu-x86_64.tar.gz"}')
+wget $(curl -s https://api.github.com/repos/AstarNetwork/Astar/releases/latest | grep "tag_name" | awk '{print "https://github.com/AstarNetwork/Astar/releases/download/" substr($2, 2, length($2)-3) "/astar-collator-v" substr($2, 3, length($2)-4) "-ubuntu-x86_64.tar.gz"}')
 ```
 
 ```


### PR DESCRIPTION
Small typo that leads to 404 Not Found.