### PR TITLE
Markdown link checker CI

### DIFF
--- a/.github/workflows/md-link-checker.yml
+++ b/.github/workflows/md-link-checker.yml
@@ -1,0 +1,19 @@
+name: Check Markdown links
+
+on:
+  pull_request:
+    branches:
+    - master
+  push:
+    branches:
+    - master
+
+jobs:
+  markdown-link-check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: gaurav-nelson/github-action-markdown-link-check@0a51127e9955b855a9bbfa1ff5577f1d1338c9a5 # 1.0.14
+      with:
+        use-quiet-mode: 'yes'
+        config-file: '.github/workflows/mlc_config.json'


### PR DESCRIPTION
Adds CI check to detect dead links in `.md` files.

Based on: https://github.com/gaurav-nelson/github-action-markdown-link-check

**NOTE** - this is still WIP, let's see how it runs before merging.