### PR TITLE
Fix mistake in the Node Maintenance page

### DIFF
--- a/docs/nodes/node-maintenance.md
+++ b/docs/nodes/node-maintenance.md
@@ -62,7 +62,7 @@ When an upgrade is necessary, node operators are be notified in our [Discord](ht
 Download the [latest release](https://github.com/AstarNetwork/Astar/releases/latest) from Github:
 
 ```sh
-wget $(curl -s https://api.github.com/repos/AstarNetwork/Astar/releases/latest | grep "tag_name" | awk '{print "https://github.com/PlasmNetwork/Plasm/releases/download/" substr($2, 2, length($2)-3) "/astar-collator-" substr($2, 3, length($2)-4) "-ubuntu-x86_64.tar.gz"}')
+wget $(curl -s https://api.github.com/repos/AstarNetwork/Astar/releases/latest | grep "tag_name" | awk '{print "https://github.com/AstarNetwork/Astar/releases/download/" substr($2, 2, length($2)-3) "/astar-collator-v" substr($2, 3, length($2)-4) "-ubuntu-x86_64.tar.gz"}')
 tar -xvf astar-collator*.tar.gz
 ```
 


### PR DESCRIPTION
Same as here: https://github.com/AstarNetwork/astar-docs/pull/192
And also changed link to `https://github.com/AstarNetwork/Astar/releases/download/`