### PR TITLE
Feature/add rust syntax support

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -6,161 +6,170 @@ const darkCodeTheme = require("prism-react-renderer/themes/dracula");
 const math = require("remark-math");
 const katex = require("rehype-katex");
 
-
 /** @type {import('@docusaurus/types').Config} */
 const config = {
-    title: "Astar Docs",
-    tagline: "Your one-stop shop for everything Astar",
-    url: "https://docs.astar.network",
-    baseUrl: "/",
-    onBrokenLinks: "throw",
-    onBrokenMarkdownLinks: "warn",
-    favicon: "img/fav.png",
-    organizationName: "AstarNetwork", // Usually your GitHub org/user name.
-    projectName: "astar-docs", // Usually your repo name.
-    plugins: ["docusaurus-plugin-sass"],
-    stylesheets: [{
-        href: 'https://cdn.jsdelivr.net/npm/katex@0.13.24/dist/katex.min.css',
-        type: 'text/css',
-        integrity: 'sha384-odtC+0UGzzFL/6PNoE8rX/SPcQDXBJ+uRepguP4QkPCm2LBxH3FA3y+fKSiJ+AmM',
-        crossorigin: 'anonymous',
-    }, ],
-
-    presets: [
-        [
-            "classic",
-            /** @type {import('@docusaurus/preset-classic').Options} */
-            ({
-                docs: {
-                    sidebarPath: require.resolve("./sidebars.js"),
-                    // Please change this to your repo.
-                    editUrl: "https://github.com/AstarNetwork/astar-docs/tree/main/",
-                    remarkPlugins: [math],
-                    rehypePlugins: [katex],
-                },
-                blog: {
-                    showReadingTime: true,
-                    // Please change this to your repo.
-                    editUrl: "https://github.com/AstarNetwork/astar-docs/tree/main/",
-                },
-                theme: {
-                    customCss: require.resolve("./src/css/custom.scss"),
-                },
-            }),
-        ],
-    ],
-
-    //Enable multilanguage support. Portuguese added as first language
-    i18n: {
-      defaultLocale: 'en',
-      locales: ['en', 'pt', 'fr', 'id'],
-      localeConfigs: {
-        en: {htmlLang: 'en-US',},
-        pt: {},
-        fr: {},
-        id: {},
-      }
+  title: "Astar Docs",
+  tagline: "Your one-stop shop for everything Astar",
+  url: "https://docs.astar.network",
+  baseUrl: "/",
+  onBrokenLinks: "throw",
+  onBrokenMarkdownLinks: "warn",
+  favicon: "img/fav.png",
+  organizationName: "AstarNetwork", // Usually your GitHub org/user name.
+  projectName: "astar-docs", // Usually your repo name.
+  plugins: ["docusaurus-plugin-sass"],
+  stylesheets: [
+    {
+      href: "https://cdn.jsdelivr.net/npm/katex@0.13.24/dist/katex.min.css",
+      type: "text/css",
+      integrity:
+        "sha384-odtC+0UGzzFL/6PNoE8rX/SPcQDXBJ+uRepguP4QkPCm2LBxH3FA3y+fKSiJ+AmM",
+      crossorigin: "anonymous",
     },
-    themeConfig:
-        /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
-        ({
-            navbar: {
-                title: "Astar Docs",
-                logo: {
-                    alt: "Astar",
-                    src: "img/astar-logo.svg",
-                },
-                items: [{
-                        type: "doc",
-                        docId: "getting-started",
-                        position: "left",
-                        label: "Docs",
-                    },
-                    {
-                        to: "https://medium.com/astar-network",
-                        label: "Medium",
-                        position: "left",
-                    },
-                    {
-                        to: 'https://www.youtube.com/channel/UC36JgEF6gqatVSK9xlzzrvQ',
-                        label: 'Youtube',
-                        position: 'left',
-                    },
-                    {
-                      type: 'localeDropdown',
-                      position: 'right',
-                    },
-                    {
-                        href: 'https://github.com/AstarNetwork/astar-docs',
-                        label: 'GitHub',
-                        position: 'right',
-                    },
-                ],
-            },
-            footer: {
-                style: "light",
-                links: [{
-                        title: "Docs",
-                        items: [{
-                            label: "Get Started",
-                            to: "/docs/getting-started",
-                        }, ],
-                    },
-                    {
-                        title: "Community",
-                        items: [{
-                                label: "Discord",
-                                href: "https://discord.gg/mWGt9bH59s",
-                            },
-                            {
-                                label: "Twitter",
-                                href: "https://twitter.com/AstarNetwork",
-                            },
-                        ],
-                    },
-                    {
-                        title: "More",
-                        items: [{
-                                label: "Blog",
-                                to: "https://medium.com/astar-network",
-                            },
-                            {
-                                label: "GitHub",
-                                href: "https://github.com/AstarNetwork",
-                            },
-                        ],
-                    },
-                ],
-                copyright: `Copyright © ${new Date().getFullYear()} Astar Developers Hub.`,
-            },
-            prism: {
-                theme: lightCodeTheme,
-                darkTheme: darkCodeTheme,
-            },
-            algolia: {
-                // The application ID provided by Algolia
-                appId: "S7S4T6Q4KC",
+  ],
 
-                // Public API key: it is safe to commit it
-                apiKey: "4eacb78946fd33fdd34c5954c4658a7b",
+  presets: [
+    [
+      "classic",
+      /** @type {import('@docusaurus/preset-classic').Options} */
+      ({
+        docs: {
+          sidebarPath: require.resolve("./sidebars.js"),
+          // Please change this to your repo.
+          editUrl: "https://github.com/AstarNetwork/astar-docs/tree/main/",
+          remarkPlugins: [math],
+          rehypePlugins: [katex],
+        },
+        blog: {
+          showReadingTime: true,
+          // Please change this to your repo.
+          editUrl: "https://github.com/AstarNetwork/astar-docs/tree/main/",
+        },
+        theme: {
+          customCss: require.resolve("./src/css/custom.scss"),
+        },
+      }),
+    ],
+  ],
 
-                indexName: "astar",
+  //Enable multilanguage support. Portuguese added as first language
+  i18n: {
+    defaultLocale: "en",
+    locales: ["en", "pt", "fr", "id"],
+    localeConfigs: {
+      en: { htmlLang: "en-US" },
+      pt: {},
+      fr: {},
+      id: {},
+    },
+  },
+  themeConfig:
+    /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
+    ({
+      navbar: {
+        title: "Astar Docs",
+        logo: {
+          alt: "Astar",
+          src: "img/astar-logo.svg",
+        },
+        items: [
+          {
+            type: "doc",
+            docId: "getting-started",
+            position: "left",
+            label: "Docs",
+          },
+          {
+            to: "https://medium.com/astar-network",
+            label: "Medium",
+            position: "left",
+          },
+          {
+            to: "https://www.youtube.com/channel/UC36JgEF6gqatVSK9xlzzrvQ",
+            label: "Youtube",
+            position: "left",
+          },
+          {
+            type: "localeDropdown",
+            position: "right",
+          },
+          {
+            href: "https://github.com/AstarNetwork/astar-docs",
+            label: "GitHub",
+            position: "right",
+          },
+        ],
+      },
+      footer: {
+        style: "light",
+        links: [
+          {
+            title: "Docs",
+            items: [
+              {
+                label: "Get Started",
+                to: "/docs/getting-started",
+              },
+            ],
+          },
+          {
+            title: "Community",
+            items: [
+              {
+                label: "Discord",
+                href: "https://discord.gg/mWGt9bH59s",
+              },
+              {
+                label: "Twitter",
+                href: "https://twitter.com/AstarNetwork",
+              },
+            ],
+          },
+          {
+            title: "More",
+            items: [
+              {
+                label: "Blog",
+                to: "https://medium.com/astar-network",
+              },
+              {
+                label: "GitHub",
+                href: "https://github.com/AstarNetwork",
+              },
+            ],
+          },
+        ],
+        copyright: `Copyright © ${new Date().getFullYear()} Astar Developers Hub.`,
+      },
+      prism: {
+        theme: lightCodeTheme,
+        darkTheme: darkCodeTheme,
+        additionalLanguages: ["rust", "toml"],
+      },
+      algolia: {
+        // The application ID provided by Algolia
+        appId: "S7S4T6Q4KC",
 
-                // Optional: see doc section below
-                contextualSearch: true,
+        // Public API key: it is safe to commit it
+        apiKey: "4eacb78946fd33fdd34c5954c4658a7b",
 
-                // Optional: Specify domains where the navigation should occur through window.location instead on history.push. Useful when our Algolia config crawls multiple documentation sites and we want to navigate with window.location.href to them.
-                externalUrlRegex: "astar\\.network",
+        indexName: "astar",
 
-                // Optional: Algolia search parameters
-                searchParameters: {},
+        // Optional: see doc section below
+        contextualSearch: true,
 
-                // Optional: path for search page that enabled by default (`false` to disable it)
-                searchPagePath: "search",
+        // Optional: Specify domains where the navigation should occur through window.location instead on history.push. Useful when our Algolia config crawls multiple documentation sites and we want to navigate with window.location.href to them.
+        externalUrlRegex: "astar\\.network",
 
-                //... other Algolia params
-            },
-        }),
+        // Optional: Algolia search parameters
+        searchParameters: {},
+
+        // Optional: path for search page that enabled by default (`false` to disable it)
+        searchPagePath: "search",
+
+        //... other Algolia params
+      },
+    }),
 };
 
 module.exports = config;

--- a/src/theme/prism-include-languages.js
+++ b/src/theme/prism-include-languages.js
@@ -1,0 +1,19 @@
+import siteConfig from '@generated/docusaurus.config';
+export default function prismIncludeLanguages(PrismObject) {
+  const {
+    themeConfig: {prism},
+  } = siteConfig;
+  const {additionalLanguages} = prism;
+  // Prism components work on the Prism instance on the window, while prism-
+  // react-renderer uses its own Prism instance. We temporarily mount the
+  // instance onto window, import components to enhance it, then remove it to
+  // avoid polluting global namespace.
+  // You can mutate PrismObject: registering plugins, deleting languages... As
+  // long as you don't re-assign it
+  globalThis.Prism = PrismObject;
+  additionalLanguages.forEach((lang) => {
+    // eslint-disable-next-line global-require, import/no-dynamic-require
+    require(`prismjs/components/prism-${lang}`);
+  });
+  delete globalThis.Prism;
+}


### PR DESCRIPTION
Ejected `prism-include-languages.js` and added `rust` and `toml` to the `additionalLanguages` field in Docusaurus config.

More languages from this list can be added if needed:
https://prismjs.com/#supported-languages