### PR TITLE
Update alt texts on Build chapter

### DIFF
--- a/docs/build/EVM/index.md
+++ b/docs/build/EVM/index.md
@@ -1,5 +1,5 @@
 # EVM Smart Contracts
-![banner](../assets/evm.png)
+![EVM smart contracts](../assets/evm.png)
 
 All Astar networks support EVM smart contracts except Swanky node.
 

--- a/docs/build/Introduction/index.md
+++ b/docs/build/Introduction/index.md
@@ -1,5 +1,5 @@
 # Introduction
-![banner](../assets/introduction.png)
+![General understanding of programming basics　](../assets/introduction.png)
 To make use of this documentation effectively, you should possess a general understanding of programming basics. The programming languages used throughout are mainly Rust, Solidity, and JavaScript, for which previous knowledge is not necessary, but would be highly beneficial. In conjunction with improving your understanding of the material contained within these guides, we recommend additionally that you review supplemental material covering these languages, in order to improve your overall understanding of the topics, and practical code examples provided. 
 
 ### Do I need blockchain knowledge to follow this documentation?

--- a/docs/build/builder-guides/index.md
+++ b/docs/build/builder-guides/index.md
@@ -1,5 +1,5 @@
 # Builder Guides
-![banner](../assets/builderguides.png)
+![Additional information to help developing on Astar Network](../assets/builderguides.png)
 
 ```mdx-code-block
 import DocCardList from '@theme/DocCardList';

--- a/docs/build/environment/index.md
+++ b/docs/build/environment/index.md
@@ -1,5 +1,5 @@
 # Setup the Development Environment
-![banner](../assets/environment.png)
+![Development Environment](../assets/environment.png)
 
 Prior to commencing development, you do not need to know how to set up these environments. However, you may want to review the following sections to become more familiar with what they do, and their specific requirements.
 

--- a/docs/build/index.md
+++ b/docs/build/index.md
@@ -1,5 +1,5 @@
 # Build on Astar
-![banner](assets/build.png)
+![Documentation of all the resources builders need in order to start testing, deploying and interacting with smart contracts on the Astar network](assets/build.png)
 
 ## Why Build on Astar
 Astar is the most flexible and interoperable decentralized application (dApp) platform in the Polkadot ecosystem, supporting both Wasm and EVM smart contracts, and hybrid Cross-VM dApps able to call into one another. Astar network provides native access to the Polkadot ecosystem through its parachain slot, and asset bridges and general message passing protocols integrated with the ecosystem  provide routes to other major blockchains, including [Ethereum](https://cbridge.celer.network/#/transfer), [BSC](https://cbridge.celer.network/#/transfer), Cosmos, Polygon, and more. Astar network's innovative dApp staking program allows developers to earn a basic income while they build out their products and communities; and Foundation, in coordination with the community, may also provide direct funding to projects through a variety of ecosystem incubation initiatives, such as #MVP2Earn.

--- a/docs/build/wasm/index.md
+++ b/docs/build/wasm/index.md
@@ -1,5 +1,5 @@
 # Wasm Smart Contracts
-![banner](../assets/wasm.png)
+![Wasm Smart Contracts](../assets/wasm.png)
 
 The **Wasm** section covers the Wasm stack on Astar/Shiden, some more advanced topics, and contains a few tutorials to help you build and deploy Wasm smart contracts.
 


### PR DESCRIPTION
Update alt texts on the following pages in the Build chapter.

Since header image Alt goes to meta og description, all alt has been updated.

<img width="822" alt="スクリーンショット 2023-02-22 16 18 45" src="https://user-images.githubusercontent.com/77480847/220689298-56cd6554-95f7-47e0-8f7c-a956078ceb57.png">

- Build
- Introduction
- Build Environment
- EVM
- Wasm
- Builder Guides