### PR TITLE
Make --enable-evm-rpc more visible

### DIFF
--- a/docs/nodes/archive-node/binary.md
+++ b/docs/nodes/archive-node/binary.md
@@ -148,6 +148,10 @@ WantedBy=multi-user.target
 </TabItem>
 </Tabs>
 
+:::important
+EVM RPC calls are disabled by default, and require additional flag to be enabled. Please refer [to this page](/docs/build/EVM/developer-tooling.md#your-own-rpc-server) for more info.
+:::
+
 Start the service:
 
 ```sh

--- a/docs/nodes/full-node.md
+++ b/docs/nodes/full-node.md
@@ -119,6 +119,10 @@ WantedBy=multi-user.target
 </TabItem>
 </Tabs>
 
+:::important
+EVM RPC calls are disabled by default, and require additional flag to be enabled. Please refer [to this page](/docs/build/EVM/developer-tooling.md#your-own-rpc-server) for more info.
+:::
+
 
 ### Docker
 


### PR DESCRIPTION
The flag for enabling EVM RPC, `--enable-evm-rpc` is _hidden_ under builders doc, and first EVM contract.

This PR enhances docs for running full & archive nodes so the EVM RPC info is more visible.