### PR TITLE
fix glossary sidebar_position

### DIFF
--- a/docs/about/glossary.md
+++ b/docs/about/glossary.md
@@ -1,123 +1,161 @@
 ---
-sidebar_position: 2
+sidebar_position: 3
 ---
 
 # Glossary
 
- ### Archive node 
-  A node that stores all historical states of a blockchain between blocks.
+### Archive node
 
- ### ASTR
- The native token of Astar. Used for dApp staking.
+A node that stores all historical states of a blockchain between blocks.
 
- ### Ask!
- An embedded domain-specific language (eDSL) for writing smart contracts based on AssemblyScript.
+### ASTR
 
- ### Bridge 
- A mechanism that allows the transfer of assets or data between two different blockchain networks.
+The native token of Astar. Used for dApp staking.
 
- ### Collator
-  A node that maintains a parachain by collecting parachain transactions and producing state transition proofs for the validators.
+### Ask!
 
- ### Cross-chain
- Ability of different blockchain networks to communicate and exchange data or assets with each other, allowing for interoperability and enhancing the functionality and scalability of blockchain ecosystems.
+An embedded domain-specific language (eDSL) for writing smart contracts based on AssemblyScript.
 
- ### DAO
- Short for Decentralized Autonomous Organization, a blockchain-based organization that allows for decentralized decision-making and management by its members.
+### Bridge
 
- ### DApp
- A generic term for a decentralized application, that is, one that runs as part of a distributed network as opposed to being run on a specific system or set of systems.
+A mechanism that allows the transfer of assets or data between two different blockchain networks.
 
- ### EVM
- short for Ethereum Virtual Machine.  A software environment that executes smart contracts on the Ethereum compatible blockchain networks.
+### Collator
 
- ### H160
- An Ethereum format address for Substrate-based blockchains.
+A node that maintains a parachain by collecting parachain transactions and producing state transition proofs for the validators.
 
- ### HRMP
- Short for Horizontal Relay-routed Message Passing. A precursor to the complete XCMP implementation, that mimics the same interface and semantics of XCMP.  The plan is to retire HRMP once the implementation of XCMP is complete.
+### Cross-chain
 
- ### Ink!
- An embedded domain-specific language (eDSL) for writing smart contracts based on Rust.
+Ability of different blockchain networks to communicate and exchange data or assets with each other, allowing for interoperability and enhancing the functionality and scalability of blockchain ecosystems.
 
- ### Layer 1
-  The underlying infrastructure of a blockchain network, which includes the block production mechanism, the data structure, and the rules for validating transactions.
+### DAO
 
- ### Layer 2
- Programs built on top of layer 1 such as smart contracts or solutions to improve scalability, reduce transaction costs, and enhance the functionality of the blockchain network.
+Short for Decentralized Autonomous Organization, a blockchain-based organization that allows for decentralized decision-making and management by its members.
 
- ### Light client
- A client that does not download the full blockchain, and instead just downloads block headers. Connects to full nodes to query data.
+### DApp
 
- ### Mainnet
- Short for "main network": the fully functional and acting chain that runs its own network.
+A generic term for a decentralized application, that is, one that runs as part of a distributed network as opposed to being run on a specific system or set of systems.
 
- ### Node
- A device connected to a blockchain network that stores a copy of the blockchain ledger and participates in validating transactions and maintaining the network's security and integrity.
+### EVM
 
- ### Pallet
- A Substrate runtime module.
+short for Ethereum Virtual Machine. A software environment that executes smart contracts on the Ethereum compatible blockchain networks.
 
- ### Parachain 
- A blockchain that meets several characteristics that allow it to work within the confines of the Polkadot Host. Also known as “parallelized chain”.
+### H160
 
- ### Polakdot
- A heterogeneous, multi-chain network allowing various blockchains of different characteristics to perform arbitrary, cross-chain communication under shared security.
+An Ethereum format address for Substrate-based blockchains.
 
- ### Relayer
- A node that relays messages between different chains in Polkadot.
+### HRMP
 
- ### Rollup
- A scaling solution that bundles multiple transactions into a single transaction to increase throughput and reduce fees on a network.
+Short for Horizontal Relay-routed Message Passing. A precursor to the complete XCMP implementation, that mimics the same interface and semantics of XCMP. The plan is to retire HRMP once the implementation of XCMP is complete.
 
- ### Sharding
- Partition of a blockchain network that allows for parallel processing of transactions to increase scalability and network capacity.
+### Ink!
 
- ### Shiden
- The "canary network" for Astar connected to Kusama, a canary network for Polkadot. It consists of an early-release, unaudited version of the Astar codebase. It is not a testnet.
+An embedded domain-specific language (eDSL) for writing smart contracts based on Rust.
 
- ### Shibuya
- A testnet for Shiden and Astar.
+### Layer 1
 
- ### Smart Contract
- A self-executing computer program that automatically enforces and executes the terms of an agreement between parties on a blockchain network.
+The underlying infrastructure of a blockchain network, which includes the block production mechanism, the data structure, and the rules for validating transactions.
 
- ### SS58 
- Standardized format for encoding and decoding account addresses. It stands for Substrate 58, where 58 refers to the base-58 encoding scheme used to encode the address and is used to represent user accounts and public keys in Substrate-based blockchains.
+### Layer 2
 
- ### Staking
- Allocating tokens to a process with defined objective (e.g. security, elections etc.) and earn rewards on the network. In Astar used to nominate dApps to provide basic income to developers.
+Programs built on top of layer 1 such as smart contracts or solutions to improve scalability, reduce transaction costs, and enhance the functionality of the blockchain network.
 
- ### Substrate 
- A modular framework for building blockchains. Astar is built with Substrate.
+### Light client
 
- ### Swanky Suit 
- A suite of tools for building Wasm smart contracts on Astar that simplifly compilation, deployment and testing.
+A client that does not download the full blockchain, and instead just downloads block headers. Connects to full nodes to query data.
 
- ### Testnet 
- Short for "test network": an experimental network where testing and development takes place. Networks are often executed on a testnet before they are deployed to a mainnet.
+### Mainnet
 
- ### Vesting
- A mechanism where a certain amount of tokens is released to the owner gradually over a period of time, often used for incentivizing long-term commitments and discouraging short-term speculation.
+Short for "main network": the fully functional and acting chain that runs its own network.
 
- ### Wallet 
- A program that allows one to store private keys and sign transactions for Astar or other blockchain networks.
+### Node
 
- ### Wasm
+A device connected to a blockchain network that stores a copy of the blockchain ledger and participates in validating transactions and maintaining the network's security and integrity.
 
- Also WebAssembly, a language-agnostic, binary instruction format for a stack-based virtual machine.
+### Pallet
 
- ### XC-20
- A standard for cross-chain assets in Polkadot ecosystem with ERC-20 interface.
+A Substrate runtime module.
 
- ### XCM 
- Short for Cross-Consensus Messaging, a **messaging format**  and language used to communicate between consensus systems.
+### Parachain
 
- ### XVM
-  Short for Cross Virtual Machine, a pallet that provides interfaces for smart contracts that run on different virtual machines to interact with each other.
+A blockchain that meets several characteristics that allow it to work within the confines of the Polkadot Host. Also known as “parallelized chain”.
 
- ### Zero-knowledge proof
- A cryptographic protocol that allows one party to prove knowledge of a secret without revealing the secret itself.
- 
+### Polakdot
+
+A heterogeneous, multi-chain network allowing various blockchains of different characteristics to perform arbitrary, cross-chain communication under shared security.
+
+### Relayer
+
+A node that relays messages between different chains in Polkadot.
+
+### Rollup
+
+A scaling solution that bundles multiple transactions into a single transaction to increase throughput and reduce fees on a network.
+
+### Sharding
+
+Partition of a blockchain network that allows for parallel processing of transactions to increase scalability and network capacity.
+
+### Shiden
+
+The "canary network" for Astar connected to Kusama, a canary network for Polkadot. It consists of an early-release, unaudited version of the Astar codebase. It is not a testnet.
+
+### Shibuya
+
+A testnet for Shiden and Astar.
+
+### Smart Contract
+
+A self-executing computer program that automatically enforces and executes the terms of an agreement between parties on a blockchain network.
+
+### SS58
+
+Standardized format for encoding and decoding account addresses. It stands for Substrate 58, where 58 refers to the base-58 encoding scheme used to encode the address and is used to represent user accounts and public keys in Substrate-based blockchains.
+
+### Staking
+
+Allocating tokens to a process with defined objective (e.g. security, elections etc.) and earn rewards on the network. In Astar used to nominate dApps to provide basic income to developers.
+
+### Substrate
+
+A modular framework for building blockchains. Astar is built with Substrate.
+
+### Swanky Suit
+
+A suite of tools for building Wasm smart contracts on Astar that simplifly compilation, deployment and testing.
+
+### Testnet
+
+Short for "test network": an experimental network where testing and development takes place. Networks are often executed on a testnet before they are deployed to a mainnet.
+
+### Vesting
+
+A mechanism where a certain amount of tokens is released to the owner gradually over a period of time, often used for incentivizing long-term commitments and discouraging short-term speculation.
+
+### Wallet
+
+A program that allows one to store private keys and sign transactions for Astar or other blockchain networks.
+
+### Wasm
+
+Also WebAssembly, a language-agnostic, binary instruction format for a stack-based virtual machine.
+
+### XC-20
+
+A standard for cross-chain assets in Polkadot ecosystem with ERC-20 interface.
+
+### XCM
+
+Short for Cross-Consensus Messaging, a **messaging format**  and language used to communicate between consensus systems.
+
+### XVM
+
+Short for Cross Virtual Machine, a pallet that provides interfaces for smart contracts that run on different virtual machines to interact with each other.
+
+### Zero-knowledge proof
+
+A cryptographic protocol that allows one party to prove knowledge of a secret without revealing the secret itself.
+
 ### Zombienet
+
 A CLI tool to easily spawn ephemeral Substrate-based networks and perform tests against them.


### PR DESCRIPTION
Due to having the same `sidebar_position` property as token-economics section, the glossary wasn't visible in the menu.

This changes it so all three items have a unique value.