### PR TITLE
feat: add cargo contract rust nightly warning

### DIFF
--- a/docs/build/environment/ink_environment.md
+++ b/docs/build/environment/ink_environment.md
@@ -56,7 +56,7 @@ targets = [ "wasm32-unknown-unknown" ]
 profile = "minimal"
 ```
 
-See more here - https://github.com/paritytech/cargo-contract/issues/1058
+See more [here](https://github.com/paritytech/cargo-contract/issues/1058)
 :::
 
 ### Ink! [CLI](https://use.ink/getting-started/setup#ink-cli)

--- a/docs/build/environment/ink_environment.md
+++ b/docs/build/environment/ink_environment.md
@@ -42,13 +42,30 @@ rustup component add rust-src --toolchain nightly
 rustup target add wasm32-unknown-unknown --toolchain nightly
 ```
 
+:::caution
+Due to a bug in `cargo-contract`, building contracts with **rust nightly 1.70.0 or higher will fail**.
+It is advised to use rustc v1.69.0 or older till the issue is resolved from `cargo-contract` side.
+For better dev experience it is advised to create a [rust-toolchain file](https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file)
+in the root of your project directory with following values.
+
+```toml
+[toolchain]
+channel = "nightly-2023-02-07"
+components = [ "rustfmt", "rust-src" ]
+targets = [ "wasm32-unknown-unknown" ]
+profile = "minimal"
+```
+
+See more here - https://github.com/paritytech/cargo-contract/issues/1058
+:::
+
 ### Ink! [CLI](https://use.ink/getting-started/setup#ink-cli)
 
 The first and most important tool we will be installing is [cargo-contract](https://github.com/paritytech/cargo-contract), a CLI tool for setting up and managing WebAssembly smart contracts written with ink!
 
 As a prerequisite using older versions of ink! you may need to install the [binaryen](https://github.com/WebAssembly/binaryen) package, used to optimize WebAssembly contract bytecode.
 
-Many package managers have it preinstalled, for example [Debian/Ubuntu](https://tracker.debian.org/pkg/binaryen), [Homebrew](https://formulae.brew.sh/formula/binaryen), and [Arch Linux](https://archlinux.org/packages/community/x86_64/binaryen/). 
+Many package managers have it preinstalled, for example [Debian/Ubuntu](https://tracker.debian.org/pkg/binaryen), [Homebrew](https://formulae.brew.sh/formula/binaryen), and [Arch Linux](https://archlinux.org/packages/community/x86_64/binaryen/).
 
 <Tabs>
 <TabItem value="Debian/Ubuntu" label="Debian/Ubuntu" default>
@@ -110,6 +127,7 @@ cargo install cargo-contract --force --locked
 Use `--force` to ensure you are updated to the most recent `cargo-contract` version.
 
 If you need to install an older version of `cargo-contract` use the following command by adding your desired version:
+
 ```bash
 cargo install cargo-contract --force --version 1.5.1
 ```

--- a/docs/build/environment/ink_environment.md
+++ b/docs/build/environment/ink_environment.md
@@ -44,7 +44,7 @@ rustup target add wasm32-unknown-unknown --toolchain nightly
 
 :::caution
 Due to a bug in `cargo-contract`, building contracts with **rust nightly 1.70.0 or higher will fail**.
-It is advised to use rustc v1.69.0 or older till the issue is resolved from `cargo-contract` side.
+It is advised to use rustc v1.69.0 or older until the issue is resolved from `cargo-contract` side.
 For better dev experience it is advised to create a [rust-toolchain file](https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file)
 in the root of your project directory with following values.
 


### PR DESCRIPTION
## Summary
There is an ongoing issue with `cargo-contract` and rust nightly - https://github.com/paritytech/cargo-contract/issues/1058
In our docs we have stated to install latest nightly which unfortunately for new uses will install rustc-1.70.0 and they will have issues with contract building.

### Changes
I've added a warning banner just below the rust setup instructions which should suffice till the issue is resolved and then we can remove it. 