### PR TITLE
Missing sudo command to change authority

### DIFF
--- a/docs/nodes/collator/secure_setup_guide/building_node.md
+++ b/docs/nodes/collator/secure_setup_guide/building_node.md
@@ -108,7 +108,7 @@ Create a dedicated user for the node and move the **node binary** (in this examp
 ```
 sudo useradd --no-create-home --shell /usr/sbin/nologin astar
 sudo cp ./astar-collator /usr/local/bin
-chmod +x /usr/local/bin/astar-collator
+sudo chmod +x /usr/local/bin/astar-collator
 ```
 
 Create a dedicated directory for the **chain storage data**:


### PR DESCRIPTION
Added the sudo command that was missing before chmod to be able to change permissions on an Ubuntu server.