### PR TITLE
fix: url in Acurast docs

### DIFF
--- a/docs/integrations/oracles/acurast.md
+++ b/docs/integrations/oracles/acurast.md
@@ -149,7 +149,7 @@ httpGET(
 1. Specify your additional parameters such as the reward.
 1. Publish your Job and wait for your first fulfillment.
 
-Or check out [How to get started with the Acurast Console](/developers/introduction#get-started) to register your Job.
+Or check out [How to get started with the Acurast Console](https://docs.acurast.com/developers/introduction#get-started) to register your Job.
 
 ## Full Documentation
 


### PR DESCRIPTION
I've corrected the wrong URL in "acurast.md" file.

