### PR TITLE
Remove XC20 revert code docs

### DIFF
--- a/docs/build/builder-guides/leverage_parachains/interact_with_xc20.md
+++ b/docs/build/builder-guides/leverage_parachains/interact_with_xc20.md
@@ -135,7 +135,7 @@ In order to confirm receiving the asset on EVM, we need to add the specific asse
 In the following section, we will demonstrate how to interact with the Cookbook Token that we created via Solidity smart contract.
 
 :::note
-💡 In order to make the mintable XC20 asset interactable via Solidity smart contract, `insufficient` needs to be set to `true`, and the EVM revert code needs to be registered. It may require technical support from the Astar Foundation team. Please submit the support request in [Astar Discord](https://discord.gg/astarnetwork) or DM `@neutrino4` on Telegram.
+💡 In order for an account to receive some of the **XC20** asset, it has to hold some native token. This can be bypassed if `isSufficient` is sufficient is set to `true`.
 :::
 
 The Solidity Interface of Mintable XC20 on Astar includes IERC20 and IERC20Plus interfaces, which are declared in [ERC20.sol](https://github.com/AstarNetwork/astar-frame/blob/polkadot-v0.9.33/precompiles/assets-erc20/ERC20.sol), and are as follows:

--- a/docs/learn/xcm/building-with-xcm/create-xc20-assets.md
+++ b/docs/learn/xcm/building-with-xcm/create-xc20-assets.md
@@ -81,21 +81,3 @@ The hex value that was already generated in the example is 7 characters long, so
 For this example, the full address is `0xFFFFFFFF00000000000000000000000001310dD5`.
 
 Now that you've generated the XC20 precompile address, you can use the address to interact with the XC20 as you would with any other ERC20 in Remix.
-
-## Accessing XC20 From a Smart Contract
-
-In order to access an XC20 via smart contract, _EVM revert code_ needs to be registered on the XC20 address, first.
-This isn't an automated process, and currently requires a small intervention on the part of the Astar team on `Astar` and `Shiden` networks.
-
-Please contact us if you cannot access an XC20 from your smart contract
-
-For `Shibuya` testnet, users can manually register the revert code using a small trick. Open `Shibuya` in [polkadot-js app](https://polkadot.js.org/apps/) (under *Test networks*) and select `Extrinsic` under `Developer` dropdown menu.
-
-Now perform the following:
-* Select `xcAssetConfig->registerAssetLocation`
-* The asset location you select is not important, but to make things more consistent and easier to follow-up, we suggest the following:
-  * `V2`
-  * `parents: 0`
-  * `interior: X1( GeneralIndex (>>your asset Id<<) )`
-* `assetId` should match your asset Id
-* Submit the extrinsic to register the revert code, which should make the XC20 asset accessible to smart contracts.


### PR DESCRIPTION
Revert code for XC20 asset will be automatically registered after the next runtime upgrade(s).
This means that parts of the docs can be removed.

Fixed one slightly incorrect explanation of `isSufficient` attribute.