### PR TITLE
add batch precompile docs

### DIFF
--- a/docs/build/EVM/precompiles/batch.md
+++ b/docs/build/EVM/precompiles/batch.md
@@ -1,0 +1,33 @@
+# Batch Precompile
+
+The batch precompiled contract enables developers to consolidate several EVM calls into a single action. Previously, if users need to engage with multiple contracts, they would need to confirm multiple transactions in their wallet. For instance, this could involve approving a token's access for a smart contract and then performing a transfer or claiming staking rewards on DappsStaking for every era.Through the batch precompile feature, developers can enhance the user experience by condensing these transactions into a batch, thereby reducing the number of confirmations needed to just one. This approach also holds the potential to lower gas fees, as batching avoids incurring multiple base gas fees.
+
+The precompile directly interacts with Substrate's EVM pallet. The caller of the batch function will have their address serve as the `msg.sender` for all subtransactions. However, unlike delegate calls, the target contract will still impact its own storage. Essentially, this process mirrors the effect of a user signing multiple transactions, but with the requirement for only a single confirmation.
+
+| Precompile | Address |
+| -------- | -------- |
+| `Batch` | 0x0000000000000000000000000000000000005006 |
+
+## The Batch Solidity Interface
+
+Batch.sol is a Solidity interface that allows developers to interact with the precompile's three methods.
+
+The interface includes the following functions:
+
+* **batchSome(address[] to, uint256[] value, bytes[] callData, uint64[] gasLimit)** — performs multiple calls, where the same index of each array combine into the information required for a single subcall. If a subcall reverts, following subcalls will still be attempted
+
+* **batchSomeUntilFailure(address[] to, uint256[] value, bytes[] callData, uint64[] gasLimit)** — performs multiple calls, where the same index of each array combine into the information required for a single subcall. If a subcall reverts, no following subcalls will be executed
+
+* **batchAll(address[] to, uint256[] value, bytes[] callData, uint64[] gasLimit)** — performs multiple calls atomically, where the same index of each array combine into the information required for a single subcall. If a subcall reverts, all subcalls will revert
+
+### Each of these functions have the following parameters:
+
+* **address[] to** - an array of addresses to direct subtransactions to, where each entry is a subtransaction
+
+* **uint256[] value** - an array of native currency values to send in the subtransactions, where the index corresponds to the subtransaction of the same index in the to array. If this array is shorter than the to array, all the following subtransactions will default to a value of 0
+
+* **bytes[] callData** - an array of call data to include in the subtransactions, where the index corresponds to the subtransaction of the same index in the to array. If this array is shorter than the to array, all of the following subtransactions will include no call data
+
+* **uint64[] gasLimit** - an array of gas limits in the subtransactions, where the index corresponds to the subtransaction of the same index in the to array. Values of 0 are interpreted as unlimited and will have all remaining gas of the batch transaction forwarded. If this array is shorter than the to array, all of the following subtransactions will have all remaining gas forwarded
+
+For more information checkout [batch](https://github.com/AstarNetwork/Astar/blob/master/precompiles/batch/Batch.sol) on [astar](https://github.com/AstarNetwork/Astar)

--- a/docs/build/EVM/precompiles/index.md
+++ b/docs/build/EVM/precompiles/index.md
@@ -28,8 +28,9 @@ The Frontier EVM used on Astar network provides several useful precompiled contr
 | [Sr25519](sr25519.md) | 0x0000000000000000000000000000000000005002     |
 | [SubstrateEcdsa](substrate-ecdsa.md) | 0x0000000000000000000000000000000000005003     |
 | [XCM](xcm.md) | 0x0000000000000000000000000000000000005004     |
-| [assets-erc20](xc20.md) | ASSET_PRECOMPILE_ADDRESS_PREFIX |
 | [XVM](xvm.md) | 0x0000000000000000000000000000000000005005 |
+| [Batch](batch.md) | 0x0000000000000000000000000000000000005006 |
+| [assets-erc20](xc20.md) | ASSET_PRECOMPILE_ADDRESS_PREFIX |
 
 The interface descriptions for these precompiles can be found in the `precompiles` folder: [astar-frame repo](https://github.com/AstarNetwork/astar-frame/).
 The Addresses can be checked in the [Astar repo](https://github.com/AstarNetwork/Astar/tree/master/runtime) for each runtime in `precompile.rs` files.


### PR DESCRIPTION
This PR adds batch precompile docs on Astar docs.

## Batch Precompile
The batch precompiled contract enables developers to consolidate several EVM calls into a single action. Previously, if users need to engage with multiple contracts, they would need to confirm multiple transactions in their wallet.

**Check list**
- [x] Add to index
- [x] Add docs
