### PR TITLE
chore(): correct content for acurast evm/wasm & zkEVM

### DIFF
--- a/docs/build/integrations/oracles/acurast.md
+++ b/docs/build/integrations/oracles/acurast.md
@@ -1,0 +1,156 @@
+---
+sidebar_position: 1
+---
+
+# Acurast
+
+[Acurast]: https://acurast.com/
+
+## Overview
+
+[Acurast](https://acurast.com/) is a platform and protocol designed to enable Web3 projects and enterprises to realize the full potential of Web3 by interconnecting worlds like Web2, Web3, AI, IOT through Acurast's Universal Interoperability.
+
+## Using Acurast
+
+Through Acurast developers can arbitrarly fetch data from public or permissioned APIs for the "Oracle" use case such as price feeds for DeFi platforms through a decentralized execution layer of off-chain workers. These [Processors](https://docs.acurast.com/acurast-processors), hosted by individuals, provide the resources of their Trusted Execution Environment that can be utilized to run computation yielding a verifiable output directly on chain. Developers can use the [Acurast Console](https://console.acurast.com/) to create new request and to get access to these interoperability resources.
+
+Acurast supports Astar's **WASM** and **EVM** environments. Contract Examples address can be found below:
+
+### Astar Destination Example
+
+WASM Smart Contract: b2o6ENagNWAxQT9f9yHFxfVMSpJA7kK6ouMhNN6veKXi3jw
+
+### Shiden Destination
+
+WASM Smart Contract: 0xDA7a001b254CD22e46d3eAB04d937489c93174C3
+
+## Obtain Data with Acurast on WASM and EVM
+
+### How to Get Started
+
+1. Deploy one of the example contracts to WASM or EVM
+1. Define your script detailing where to fetch data, computation etc.
+1. Create a Job on the [Acurast Console](https://console.acurast.com/)
+1. Processors will fulfill verifiable outputs in your defined interval to your contract
+
+### WASM Example
+
+The following example shows simple WASM smart contracts implemented with [ink!](https://use.ink/).
+
+Keep in mind that you can do much more with Acurast and get access to all interoperability modules besides these examples.
+
+```rust
+#![cfg_attr(not(feature = "std"), no_std)]
+
+use ink;
+
+#[ink::contract]
+mod receiver {
+    #[ink(storage)]
+    pub struct Receiver {
+        price: u128,
+    }
+
+    impl Receiver {
+        #[ink(constructor)]
+        pub fn default() -> Self {
+            Self {
+                price: Default::default(),
+            }
+        }
+
+        #[ink(message)]
+        pub fn fulfill(&mut self, price: u128) {
+            self.price = price;
+        }
+
+        #[ink(message)]
+        pub fn get_price(&self) -> u128 {
+            self.price
+        }
+    }
+}
+
+```
+
+### EVM Example
+
+```ts
+pragma solidity 0.8.10;
+
+/**
+ * @title Simple price feed contract
+ */
+contract PriceFeed {
+    // Account authorized to update the prices
+    address public provider = 0xF7498512502f90aA1ff299b93927417461EC7Bd5;
+
+    // Callable by other contracts
+    uint128 public price;
+
+    /**
+     * Provide the latest price
+     */
+    function fulfill(uint128 new_price) external {
+        require(msg.sender == provider, "NOT_PROVIDER");
+        price = new_price;
+    }
+}
+```
+
+### Script
+
+This example script shows how a "Price Feeds" is fetched from Binance and pushed to a WASM smart contract. You can view and test the your script on the Acurast Console.
+
+```js
+const callIndex = "0x4606"; // the call index for the 'call' extrinsic.
+const destination = "b2o6ENagNWAxQT9f9yHFxfVMSpJA7kK6ouMhNN6veKXi3jw"; // contract address that will receive the 'fulfill' call.
+_STD_.chains.substrate.signer.setSigner("SECP256K1"); // the type of signer used for sign the extrinsic call
+httpGET(
+  "https://api.binance.com/api/v3/ticker/price?symbol=AAVEBUSD",
+  {},
+  (response, _certificate) => {
+    const price = JSON.parse(response)["price"] * 10 ** 18;
+    const payload = _STD_.chains.substrate.codec.encodeUnsignedNumber(
+      price,
+      128
+    );
+    _STD_.chains.substrate.contract.fulfill(
+      "https://rpc.astar.network",
+      callIndex,
+      destination,
+      payload,
+      {
+        refTime: "3951114240",
+        proofSize: "125952",
+      },
+      (opHash) => {
+        print("Succeeded: " + opHash);
+      },
+      (err) => {
+        print("Failed fulfill: " + err);
+      }
+    );
+  },
+  (err) => {
+    print("Failed get price: " + err);
+  }
+);
+```
+
+### Job Specification
+
+1. Go to the [Acurast Console](https://console.acurast.com/) and log in with your [Talisman Wallet](https://www.talisman.xyz/wallet) or your [PolkadotJS Extension](https://polkadot.js.org/extension/).
+1. Go to "Create Job" and select your destination, the ecosystem you're building in.
+1. Select an existing template, adapt it or write your own code that fits your needs. Test your code with "Test Code".
+1. Select your own Processor or use public ones.
+1. Define your execution schedule with the parameters such as start and endtime, interval etc.
+1. Specify your usage parameters.
+1. Specify your additional parameters such as the reward.
+1. Publish your Job and wait for your first fulfillment.
+
+Or check out [How to get started with the Acurast Console](https://console.acurast.com/developers/introduction#get-started) to register your Job.
+
+## Full Documentation
+
+You can find Acurast's official documentation [here](https://docs.acurast.com/).

--- a/docs/build/zkEVM/integrations/oracles/acurast.md
+++ b/docs/build/zkEVM/integrations/oracles/acurast.md
@@ -4,153 +4,63 @@ sidebar_position: 1
 
 # Acurast
 
-[Acurast]: https://acurast.com/
+## Introduction
 
-## Overview
+[Acurast](https://acurast.com/) is a platform for Zero Trust applications, leveraging a decentralized and decentralized and trustless off-chain Compute Execution Layer for compute leveraging mobile hardware with its advantages in security, compute performance and energy efficiency. Opening the possibilities for developers to execute arbitrary code and build serverless applications that can interact with Astar's zkEVM and other ecosystems.
 
-[Acurast](https://acurast.com/) is a platform and protocol designed to enable Web3 projects and enterprises to realize the full potential of Web3 by interconnecting worlds like Web2, Web3, AI, IOT through Acurast's Universal Interoperability.
+## Acurast Price Feeds
 
-## Using Acurast
+Acurast provides price feeds for 10 assets with an update interval of 5 minutes. APIs are called through Acurast's Compute Execution Layer from multiple trustless devices, resulting in a verifiable price feed on-chain.
 
-Through Acurast developers can arbitrarly fetch data from public or permissioned APIs for the "Oracle" use case such as price feeds for DeFi platforms through a decentralized execution layer of off-chain workers. These [Processors](https://docs.acurast.com/acurast-processors), hosted by individuals, provide the resources of their Trusted Execution Environment that can be utilized to run computation yielding a verifiable output directly on chain. Developers can use the [Acurast Console](https://console.acurast.com/) to create new request and to get access to these interoperability resources.
+### Chainlink Compatible Price Feeds
 
-Acurast supports Astar's **WASM** and **EVM** environments. Contract Examples address can be found below:
+The following price feeds are Chainlink compatible, if your application is already deployed in an environment where Chainlink might be available, you can use these contracts as a drop-in replacement.
 
-### Astar Destination Example
+| Pair      | Address and info                                                                                                                |
+| --------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| ASTR/USD  | [0xde4F97786EAB4e47b96A0A65EdD7755895077073](https://zkatana.blockscout.com/address/0xde4F97786EAB4e47b96A0A65EdD7755895077073) |
+| MATIC/USD | [0x77Ed3BAc1B3Dd4DBB8D2636b6f3adFd4f21d15B3](https://zkatana.blockscout.com/address/0x77Ed3BAc1B3Dd4DBB8D2636b6f3adFd4f21d15B3) |
+| BTC/USD   | [0xDBb23274EE9354367155C290c673733374d57967](https://zkatana.blockscout.com/address/0xDBb23274EE9354367155C290c673733374d57967) |
+| ETH/USD   | [0x448786CD6E53E706AEdd984C620D63d48B720e6A](https://zkatana.blockscout.com/address/0x448786CD6E53E706AEdd984C620D63d48B720e6A) |
+| BNB/USD   | [0xb6B94e18957376ac6d22bAF31C7BF1661B238F4A](https://zkatana.blockscout.com/address/0xb6B94e18957376ac6d22bAF31C7BF1661B238F4A) |
+| USDT/USD  | [0xD12ad062A6bFBB27024a7B76E4EF7FDC5bf49Aeb](https://zkatana.blockscout.com/address/0xD12ad062A6bFBB27024a7B76E4EF7FDC5bf49Aeb) |
+| USDC/USD  | [0x2E23a70dfe6059f9F2DC35C1e940e3B3288BDE04](https://zkatana.blockscout.com/address/0x2E23a70dfe6059f9F2DC35C1e940e3B3288BDE04) |
+| DAI/USD   | [0xEC6985D9eA362fb85fEa72263169C375F8f065E7](https://zkatana.blockscout.com/address/0xEC6985D9eA362fb85fEa72263169C375F8f065E7) |
+| STETH/USD | [0xA2FB708105a412710Df254D7406A27764408A657](https://zkatana.blockscout.com/address/0xA2FB708105a412710Df254D7406A27764408A657) |
+| DOT/USD   | [0x208f799E0EE205bc6607Fae430485c66F9fe6012](https://zkatana.blockscout.com/address/0x208f799E0EE205bc6607Fae430485c66F9fe6012) |
 
-WASM Smart Contract: b2o6ENagNWAxQT9f9yHFxfVMSpJA7kK6ouMhNN6veKXi3jw
+If you need a price feed for assets or pairs not listed here, you can easily build your own price feeds here through the [Acurast Console](https://console.acurast.com/).
 
-### Shiden Destination
+## Build Your Own Zero Trust App
 
-WASM Smart Contract: 0xDA7a001b254CD22e46d3eAB04d937489c93174C3
+Acurast offers off-chain Compute Execution Layer with the following main primitives:
 
-## Obtain Data with Acurast on WASM and EVM
+- trustless: trust not in individuals but technology and cryptography, building on hardware Trusted Execution Environments.
+- decentralized: anyone across the world can participate in becoming a provider of infrastructure, Acurast Processor.
+- versatile: Developers code their apps, tailored to their use cases and deploy them.
+- confidential: Data processes on Acurast Processors is not visible to the ones providing compute resources.
 
-### How to Get Started
+Learn More on Acurast in the [Acurast](https://docs.acurast.com/).
 
-1. Deploy one of the example contracts to WASM or EVM
-1. Define your script detailing where to fetch data, computation etc.
-1. Create a Job on the [Acurast Console](https://console.acurast.com/)
-1. Processors will fulfill verifiable outputs in your defined interval to your contract
+### Get Started
 
-### WASM Example
+1. Go to the [Acurast Console](https://console.acurast.com/), log in with your wallet or [create a wallet](https://docs.acurast.com/developers/create-address).
+1. Claim free cACU Canary funds with “Fund Account”.
+1. Go to [Create Job](https://console.acurast.com/) and select “Astar” and "zKatana".
+1. Deploy your contract that you will use to receive the output of the computation, [find simple examples here](https://docs.acurast.com/integrations/evm).
+1. Create your script that you want e.g. a specific price feed, verifiable randomness, on-chain automation etc. Add your destination contract to the script. Templates can be found in the Console, [find simple examples here](https://docs.acurast.com/developers/get-started)
+1. Define the job parameters, select “Public Processors”, start and end time, interval, number of Processors and the reward in cACU that you're willing to reward for running your zero trust app.
+1. Sign the transaction to “Publish Job”.
+1. Your request is being matched to eligible Processors, these Processors will execute your app and provide the output directly to the contract you've provided. You can see the assigned Processors in the Job details, send some zKatana testnet funds to each of the "Ethereum" labeled addresses.
+1. Processors will run your app and push the output directly to your contract.
 
-The following example shows simple WASM smart contracts implemented with [ink!](https://use.ink/).
+### Learn More
 
-Keep in mind that you can do much more with Acurast and get access to all interoperability modules besides these examples.
+Do you have any questions? Join us on Telegram or Discord.
 
-```rust
-#![cfg_attr(not(feature = "std"), no_std)]
-
-use ink;
-
-#[ink::contract]
-mod receiver {
-    #[ink(storage)]
-    pub struct Receiver {
-        price: u128,
-    }
-
-    impl Receiver {
-        #[ink(constructor)]
-        pub fn default() -> Self {
-            Self {
-                price: Default::default(),
-            }
-        }
-
-        #[ink(message)]
-        pub fn fulfill(&mut self, price: u128) {
-            self.price = price;
-        }
-
-        #[ink(message)]
-        pub fn get_price(&self) -> u128 {
-            self.price
-        }
-    }
-}
-
-```
-
-### EVM Example
-
-```ts
-pragma solidity 0.8.10;
-
-/**
- * @title Simple price feed contract
- */
-contract PriceFeed {
-    // Account authorized to update the prices
-    address public provider = 0xF7498512502f90aA1ff299b93927417461EC7Bd5;
-
-    // Callable by other contracts
-    uint128 public price;
-
-    /**
-     * Provide the latest price
-     */
-    function fulfill(uint128 new_price) external {
-        require(msg.sender == provider, "NOT_PROVIDER");
-        price = new_price;
-    }
-}
-```
-
-### Script
-
-This example script shows how a "Price Feeds" is fetched from Binance and pushed to a WASM smart contract. You can view and test the your script on the Acurast Console.
-
-```js
-const callIndex = "0x4606"; // the call index for the 'call' extrinsic.
-const destination = "b2o6ENagNWAxQT9f9yHFxfVMSpJA7kK6ouMhNN6veKXi3jw"; // contract address that will receive the 'fulfill' call.
-_STD_.chains.substrate.signer.setSigner("SECP256K1"); // the type of signer used for sign the extrinsic call
-httpGET(
-  "https://api.binance.com/api/v3/ticker/price?symbol=AAVEBUSD",
-  {},
-  (response, _certificate) => {
-    const price = JSON.parse(response)["price"] * 10 ** 18;
-    const payload = _STD_.chains.substrate.codec.encodeUnsignedNumber(
-      price,
-      128
-    );
-    _STD_.chains.substrate.contract.fulfill(
-      "https://rpc.astar.network",
-      callIndex,
-      destination,
-      payload,
-      {
-        refTime: "3951114240",
-        proofSize: "125952",
-      },
-      (opHash) => {
-        print("Succeeded: " + opHash);
-      },
-      (err) => {
-        print("Failed fulfill: " + err);
-      }
-    );
-  },
-  (err) => {
-    print("Failed get price: " + err);
-  }
-);
-```
-
-### Job Specification
-
-1. Go to the [Acurast Console](https://console.acurast.com/) and log in with your [Talisman Wallet](https://www.talisman.xyz/wallet) or your [PolkadotJS Extension](https://polkadot.js.org/extension/).
-1. Go to "Create Job" and select your destination, the ecosystem you're building in.
-1. Select an existing template, adapt it or write your own code that fits your needs. Test your code with "Test Code".
-1. Select your own Processor or use public ones.
-1. Define your execution schedule with the parameters such as start and endtime, interval etc.
-1. Specify your usage parameters.
-1. Specify your additional parameters such as the reward.
-1. Publish your Job and wait for your first fulfillment.
-
-Or check out [How to get started with the Acurast Console](https://console.acurast.com/developers/introduction#get-started) to register your Job.
-
-## Full Documentation
-
-You can find Acurast's official documentation [here](https://docs.acurast.com/).
+- [Developer Docs](https://docs.acurast.com/)
+- [GitHub](https://github.com/Acurast)
+- [Website](https://acurast.com/)
+- [Telegram](https://t.me/acurastnetwork)
+- [Discord](https://discord.gg/wqgC6b6aKe)
+- [X](http://x.com/Acurast)


### PR DESCRIPTION
This PR re-adds the zkEVM content for Acurast and moves the evm/wasm content back to the initial location.