### PR TITLE
Fix/typo binaries

### DIFF
--- a/docs/build/nodes/archive-node/binary.md
+++ b/docs/build/nodes/archive-node/binary.md
@@ -82,7 +82,7 @@ ExecStart=/usr/local/bin/astar-collator \
   --rpc-methods Safe \
   --rpc-max-request-size 1 \
   --rpc-max-response-size 1 \
-  --telemetry-url 'wss://telemetry.polkadot.io/submit/ 0' \
+  --telemetry-url 'wss://telemetry.polkadot.io/submit/ 0'
 
 Restart=always
 RestartSec=10
@@ -112,7 +112,7 @@ ExecStart=/usr/local/bin/astar-collator \
   --rpc-methods Safe \
   --rpc-max-request-size 1 \
   --rpc-max-response-size 1 \
-  --telemetry-url 'wss://telemetry.polkadot.io/submit/ 0' \
+  --telemetry-url 'wss://telemetry.polkadot.io/submit/ 0'
 
 Restart=always
 RestartSec=10
@@ -142,7 +142,7 @@ ExecStart=/usr/local/bin/astar-collator \
   --rpc-methods Safe \
   --rpc-max-request-size 1 \
   --rpc-max-response-size 1 \
-  --telemetry-url 'wss://telemetry.polkadot.io/submit/ 0' \
+  --telemetry-url 'wss://telemetry.polkadot.io/submit/ 0'
 
 Restart=always
 RestartSec=10

--- a/docs/build/nodes/archive-node/docker.md
+++ b/docs/build/nodes/archive-node/docker.md
@@ -52,7 +52,7 @@ astar-collator \
 --rpc-methods Safe \
 --rpc-max-request-size 1 \
 --rpc-max-response-size 1 \
---telemetry-url 'wss://telemetry.polkadot.io/submit/ 0' \
+--telemetry-url 'wss://telemetry.polkadot.io/submit/ 0'
 ```
 
 </TabItem>
@@ -77,7 +77,7 @@ astar-collator \
 --rpc-methods Safe \
 --rpc-max-request-size 1 \
 --rpc-max-response-size 1 \
---telemetry-url 'wss://telemetry.polkadot.io/submit/ 0' \
+--telemetry-url 'wss://telemetry.polkadot.io/submit/ 0'
 ```
 
 </TabItem>
@@ -102,7 +102,7 @@ astar-collator \
 --rpc-methods Safe \
 --rpc-max-request-size 1 \
 --rpc-max-response-size 1 \
---telemetry-url 'wss://telemetry.polkadot.io/submit/ 0' \
+--telemetry-url 'wss://telemetry.polkadot.io/submit/ 0'
 ```
 
 </TabItem>

--- a/docs/build/nodes/collator/secure_setup_guide/building_node.md
+++ b/docs/build/nodes/collator/secure_setup_guide/building_node.md
@@ -197,7 +197,7 @@ ExecStart=/usr/local/bin/astar-collator \
   --base-path /var/lib/astar \
   --pruning archive \
   --trie-cache-size 0 \
-  --telemetry-url 'wss://telemetry.polkadot.io/submit/ 0' \
+  --telemetry-url 'wss://telemetry.polkadot.io/submit/ 0'
 
 Restart=always
 RestartSec=120
@@ -224,7 +224,7 @@ ExecStart=/usr/local/bin/astar-collator \
   --base-path /var/lib/astar \
   --pruning archive \
   --trie-cache-size 0 \
-  --telemetry-url 'wss://telemetry.polkadot.io/submit/ 0' \
+  --telemetry-url 'wss://telemetry.polkadot.io/submit/ 0'
 
 Restart=always
 RestartSec=120
@@ -251,7 +251,7 @@ ExecStart=/usr/local/bin/astar-collator \
   --base-path /var/lib/astar \
   --pruning archive \
   --trie-cache-size 0 \
-  --telemetry-url 'wss://telemetry.polkadot.io/submit/ 0' \
+  --telemetry-url 'wss://telemetry.polkadot.io/submit/ 0'
 
 Restart=always
 RestartSec=120

--- a/docs/build/nodes/collator/spinup_collator.md
+++ b/docs/build/nodes/collator/spinup_collator.md
@@ -24,7 +24,7 @@ Collators are responsible for the network stability, it is very important to be 
   --base-path /var/lib/astar \
   --pruning archive \
   --trie-cache-size 0 \
-  --telemetry-url 'wss://telemetry.polkadot.io/submit/ 0' \
+  --telemetry-url 'wss://telemetry.polkadot.io/submit/ 0'
 ```
 
 </TabItem>
@@ -38,7 +38,7 @@ Collators are responsible for the network stability, it is very important to be 
   --base-path /var/lib/astar \
   --pruning archive \
   --trie-cache-size 0 \
-  --telemetry-url 'wss://telemetry.polkadot.io/submit/ 0' \
+  --telemetry-url 'wss://telemetry.polkadot.io/submit/ 0'
 ```
 
 </TabItem>
@@ -52,7 +52,7 @@ Collators are responsible for the network stability, it is very important to be 
   --base-path /var/lib/astar \
   --pruning archive \
   --trie-cache-size 0 \
-  --telemetry-url 'wss://telemetry.polkadot.io/submit/ 0' \
+  --telemetry-url 'wss://telemetry.polkadot.io/submit/ 0'
 ```
 
 </TabItem>

--- a/docs/build/nodes/evm-tracing-node.md
+++ b/docs/build/nodes/evm-tracing-node.md
@@ -92,7 +92,7 @@ ExecStart=/usr/local/bin/astar-collator \
   --enable-evm-rpc \
   --ethapi=txpool,debug,trace \
   --wasm-runtime-overrides /var/lib/astar/wasm \
-  --telemetry-url 'wss://telemetry.polkadot.io/submit/ 0' \
+  --telemetry-url 'wss://telemetry.polkadot.io/submit/ 0'
 
 Restart=always
 RestartSec=10
@@ -127,7 +127,7 @@ ExecStart=/usr/local/bin/astar-collator \
   --enable-evm-rpc  \
   --ethapi=txpool,debug,trace \
   --wasm-runtime-overrides /var/lib/astar/wasm \
-  --telemetry-url 'wss://telemetry.polkadot.io/submit/ 0' \
+  --telemetry-url 'wss://telemetry.polkadot.io/submit/ 0'
 
 Restart=always
 RestartSec=10
@@ -161,7 +161,7 @@ ExecStart=/usr/local/bin/astar-collator \
   --enable-evm-rpc  \
   --ethapi=txpool,debug,trace \
   --wasm-runtime-overrides /var/lib/astar/wasm \
-  --telemetry-url 'wss://telemetry.polkadot.io/submit/ 0' \
+  --telemetry-url 'wss://telemetry.polkadot.io/submit/ 0'
 
 Restart=always
 RestartSec=10

--- a/docs/build/nodes/node-commands.md
+++ b/docs/build/nodes/node-commands.md
@@ -35,7 +35,7 @@ ExecStart=/usr/local/bin/astar-collator \
   --chain astar \
   --base-path /var/lib/astar \
   --trie-cache-size 0 \
-  --telemetry-url 'wss://telemetry.polkadot.io/submit/ 0' \
+  --telemetry-url 'wss://telemetry.polkadot.io/submit/ 0'
 
 Restart=always
 RestartSec=10
@@ -62,7 +62,7 @@ ExecStart=/usr/local/bin/astar-collator \
   --chain shiden \
   --base-path /var/lib/astar \
   --trie-cache-size 0 \
-  --telemetry-url 'wss://telemetry.polkadot.io/submit/ 0' \
+  --telemetry-url 'wss://telemetry.polkadot.io/submit/ 0'
 
 Restart=always
 RestartSec=10
@@ -89,7 +89,7 @@ ExecStart=/usr/local/bin/astar-collator \
   --chain shibuya \
   --base-path /var/lib/astar \
   --trie-cache-size 0 \
-  --telemetry-url 'wss://telemetry.polkadot.io/submit/ 0' \
+  --telemetry-url 'wss://telemetry.polkadot.io/submit/ 0'
 
 Restart=always
 RestartSec=10
@@ -120,7 +120,7 @@ astar-collator \
 --chain astar \
 --base-path /data \
 --trie-cache-size 0 \
---telemetry-url 'wss://telemetry.polkadot.io/submit/ 0' \
+--telemetry-url 'wss://telemetry.polkadot.io/submit/ 0'
 ```
 
 </TabItem>
@@ -140,7 +140,7 @@ astar-collator \
 --chain shiden \
 --base-path /data \
 --trie-cache-size 0 \
---telemetry-url 'wss://telemetry.polkadot.io/submit/ 0' \
+--telemetry-url 'wss://telemetry.polkadot.io/submit/ 0'
 ```
 
 </TabItem>
@@ -160,7 +160,7 @@ astar-collator \
 --chain shibuya \
 --base-path /data \
 --trie-cache-size 0 \
---telemetry-url 'wss://telemetry.polkadot.io/submit/ 0' \
+--telemetry-url 'wss://telemetry.polkadot.io/submit/ 0'
 ```
 
 </TabItem>
@@ -192,7 +192,7 @@ ExecStart=/usr/local/bin/astar-collator \
   --rpc-methods Safe \
   --rpc-max-request-size 1 \
   --rpc-max-response-size 1 \
-  --telemetry-url 'wss://telemetry.polkadot.io/submit/ 0' \
+  --telemetry-url 'wss://telemetry.polkadot.io/submit/ 0'
   
 Restart=always
 RestartSec=10
@@ -222,7 +222,7 @@ ExecStart=/usr/local/bin/astar-collator \
   --rpc-methods Safe \
   --rpc-max-request-size 1 \
   --rpc-max-response-size 1 \
-  --telemetry-url 'wss://telemetry.polkadot.io/submit/ 0' \
+  --telemetry-url 'wss://telemetry.polkadot.io/submit/ 0'
   
 Restart=always
 RestartSec=10
@@ -252,7 +252,7 @@ ExecStart=/usr/local/bin/astar-collator \
   --rpc-methods Safe \
   --rpc-max-request-size 1 \
   --rpc-max-response-size 1 \
-  --telemetry-url 'wss://telemetry.polkadot.io/submit/ 0' \
+  --telemetry-url 'wss://telemetry.polkadot.io/submit/ 0'
 
 Restart=always
 RestartSec=10
@@ -287,7 +287,7 @@ astar-collator \
 --rpc-methods Safe \
 --rpc-max-request-size 1 \
 --rpc-max-response-size 1 \
---telemetry-url 'wss://telemetry.polkadot.io/submit/ 0' \
+--telemetry-url 'wss://telemetry.polkadot.io/submit/ 0'
 ```
 
 </TabItem>
@@ -311,7 +311,7 @@ astar-collator \
 --rpc-methods Safe \
 --rpc-max-request-size 1 \
 --rpc-max-response-size 1 \
---telemetry-url 'wss://telemetry.polkadot.io/submit/ 0' \
+--telemetry-url 'wss://telemetry.polkadot.io/submit/ 0'
 ```
 
 </TabItem>
@@ -335,7 +335,7 @@ astar-collator \
 --rpc-methods Safe \
 --rpc-max-request-size 1 \
 --rpc-max-response-size 1 \
---telemetry-url 'wss://telemetry.polkadot.io/submit/ 0' \
+--telemetry-url 'wss://telemetry.polkadot.io/submit/ 0'
 ```
 
 </TabItem>

--- a/docs/build/nodes/rpi-cheat-sheet.md
+++ b/docs/build/nodes/rpi-cheat-sheet.md
@@ -107,7 +107,7 @@ sudo nano /etc/systemd/system/astar.service
     --name {NODE_NAME} \
     --chain astar \
     --base-path /var/lib/astar \
-    --telemetry-url 'wss://telemetry.polkadot.io/submit/ 0' \
+    --telemetry-url 'wss://telemetry.polkadot.io/submit/ 0'
 
     Restart=always
     RestartSec=10


### PR DESCRIPTION
Extra backslash is expecting command line to continue, so it's not needed.