### PR TITLE
Add ZKEVM_NET Param

### DIFF
--- a/docs/build/zkEVM/zk-node/setup-rpc-node.md
+++ b/docs/build/zkEVM/zk-node/setup-rpc-node.md
@@ -64,6 +64,7 @@ Set local variables.
 
 ```
 # define installation and config path
+ZKEVM_NET=testnet
 ZKEVM_DIR=/etc/zkevm/install
 ZKEVM_CONFIG_DIR=/etc/zkevm/config
 ```
@@ -120,7 +121,7 @@ sudo docker compose --env-file $ZKEVM_CONFIG_DIR/.env -f $ZKEVM_DIR/$ZKEVM_NET/d
 Verify that all containers are up and running: you should see the 5 containers with a status Up.
 
 ```bash
-docker ps
+sudo docker ps
 ```
 
 Now you have an **Astar zkEVM** RPC node up and running on port 8545, you just have to wait for it to synchronize.
@@ -130,7 +131,7 @@ Now you have an **Astar zkEVM** RPC node up and running on port 8545, you just h
 View container logs.
 
 ```bash
-docker logs -fn30 <container-name>
+sudo docker logs -fn30 <container-name>
 ```
 
 Test RPC requests.


### PR DESCRIPTION
I found that I need "export ZKEVM_NET=testnet" in this astar document.
I think it would be better to add this  before "Copy the env file and edit the L1 RPC URL.". 

Otherwise the following command will fail in this process:
`cp $ZKEVM_DIR/$ZKEVM_NET/example.env $ZKEVM_CONFIG_DIR/.env`

In addition, I added "sudo" which is necessary for the user assumed in this step to execute the docker command.

I suggest this update.