### PR TITLE
Update Astar Docs with references to Astar Network Audit Reports repository

### DIFF
--- a/docs/build/astar-beta-labs/account-unification/index.md
+++ b/docs/build/astar-beta-labs/account-unification/index.md
@@ -17,6 +17,10 @@ All the solutions that require performing actions on other VMs, i.e interoperabi
 Throughout this doc we will use words “address” and “account” interchangeably, although they are different in literal sense, in the context of this doc they are treated the same.
 :::
 
+:::info
+Account Unification codebase has been audited in December 2023 - Audit report is available on [Astar Network Audit Reports](https://github.com/AstarNetwork/Audits)
+:::
+
 ### How does `frontier` handle accounts?
 
 Put simply, there are a set of Native Substrate accounts existing in parallel to the EVM accounts managed by the `frontier` pallet, and one-to-one mappings from the Substrate accounts to EVM accounts are defined by a conversion trait called `AddressMapping` in the `frontier` pallet’s config.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -16,3 +16,7 @@ Astar is an interoperable blockchain platform for Polkadot and Ethereum ecosyste
 - [**XCM**](/docs/learn/interoperability/xcm) - Explains how XCM is used in Astar and also how developers can use it to interact with the rest of the Polkadot network.
 - [**Integrations**](/docs/build/integrations/) - Provides relevant information about the wallets, indexers, and oracles that are integrated with the network.
 - [**Docs Integration Request**](https://github.com/AstarNetwork/astar-docs/blob/main/docs-integration-request.md) - Provides information about how to make a documentation integration request for this repository. 
+
+## Audit Reports
+
+A comprehensive list of finalized audit reports of Astar Network's codebase ia available on GitHub - [Astar Network Audit Reports](https://github.com/AstarNetwork/Audits)


### PR DESCRIPTION
As agreed within the Dev team, audit reports will be published under a dedicated Git Hub repo. Adding links to that repo from the Getting Started page as well as from the index page of Account Unification (as final audit report is now available on the dedicated repo)


@meganskye if you think some other place is more appropriate to cross-link the repo (instead of Getting Started Page) - feel free to suggest!
