### PR TITLE
Fix docker deployment command

### DIFF
--- a/docs/build/nodes/archive-node/docker.md
+++ b/docs/build/nodes/archive-node/docker.md
@@ -71,7 +71,7 @@ astar-collator \
 --pruning archive \
 --rpc-cors all \
 --name {NODE_NAME} \
---chain astar \
+--chain shiden \
 --base-path /data \
 --rpc-external \
 --rpc-methods Safe \
@@ -96,7 +96,7 @@ astar-collator \
 --pruning archive \
 --rpc-cors all \
 --name {NODE_NAME} \
---chain astar \
+--chain shibuya \
 --base-path /data \
 --rpc-external \
 --rpc-methods Safe \


### PR DESCRIPTION
The argument, "chain," should be the name of the chain (i.e. astar, shiden, or shibuya) the node is meant for