### PR TITLE
Consolidating dApp Staking v3 docs

### DIFF
--- a/docs/build/dapp-staking/index.md
+++ b/docs/build/dapp-staking/index.md
@@ -1,8 +1,4 @@
-# dApp Staking
-
-Introducing #Build2Earn: What is dApp Staking and Why It Matters for Web3
-
-## dApp Staking & Web3
+# dApp Staking & Web3
 
 At Astar, we are on a mission to revolutionize the internet. We envision a future where the internet is truly decentralized, and not controlled by a handful of tech giants. We believe the internet should be free and owned by the people for the people. We believe that people should have ownership of their data and assets, and not be at the mercy of intermediaries. This is the essence of the Web3 vision and what drives Astar.
 
@@ -17,6 +13,10 @@ DApp staking is one of the catalysts that will accelerate the Web3 vision from a
 At Astar Network, we are tackling these three challenges head-on.
 
 The third point, namely — the necessity for great dApps to be built — is the driving force behind **#Build2Earn (our dApp staking initiative)** and the focus of this article.
+
+:::info
+Full overview of dAppStaking v3 can be found in the [Learn/dAppStaking](/docs/learn/dapp-staking/) section of the docs.
+:::
 
 ## What is dApp Staking?
 

--- a/docs/learn/dapp-staking-v3/_category_.json
+++ b/docs/learn/dapp-staking-v3/_category_.json
@@ -1,0 +1,4 @@
+{
+    "label": "dApp Staking v3",
+    "position": 4
+}

--- a/docs/learn/dapp-staking-v3/dapp-staking-faq.md
+++ b/docs/learn/dapp-staking-v3/dapp-staking-faq.md
@@ -8,7 +8,7 @@ sidebar_label: dApp Staking FAQ
 
 ## General Info About Migration From v2 to v3
 
-These are major remars about the migration:
+These are major remarks about the migration:
 
 - All registered dApps will be migrated, no actions required from the owners.
 - Staker’s _locked_ tokens will be migrated.
@@ -43,7 +43,7 @@ Using the new delegated calls, anyone will be able to claim rewards for anyone e
 
 Astar team will ensure that all pending rewards are claimed during the decommissioning. We won’t launch v3 until all unclaimed rewards have been claimed.
 
-These transactions won’t be _free_, and whoever runs the _claim bot_ will need to be reimbursed by the treasury - but this is another topic. **TODO - please refer here for more info.**
+These transactions won’t be _free_, and whoever runs the _claim bot_ will need to be reimbursed by the treasury - but this is another topic. **TODO - please refer [here](https://forum.astar.network/t/dapp-staking-migration-from-v2-to-v3/5807?u=gaius_sama) for more info.**
 
 Please do your best to claim the rewards yourself, and encourage others to do the same. This is just a one time thing, and won’t be something used again in dApp staking v3. Everyone is responsible for claiming their own rewards - also, with the new periods system, stakers will need to claim rewards & stake again roughly every 3 months to continue earning rewards.
 

--- a/docs/learn/dapp-staking-v3/dapp-staking-faq.md
+++ b/docs/learn/dapp-staking-v3/dapp-staking-faq.md
@@ -1,0 +1,82 @@
+---
+sidebar_position: 3
+title: FAQs related to dAppStaking v3
+sidebar_label: dApp Staking FAQ
+---
+
+# dAppStaking v3 FAQ
+
+## General Info About Migration From v2 to v3
+
+These are major remars about the migration:
+
+- All registered dApps will be migrated, no actions required from the owners.
+- Staker’s _locked_ tokens will be migrated.
+- Stakes **WILL NOT** be migrated, all stakers will need to pick which dApp(s) to stake on again.
+  - This is required to keep in line with the new _periods_ and stake reset.
+  - **It’s important for stakers to stake again their tokens to continue earning rewards**.
+- Once v3 is deployed, v2 will be removed.
+
+If any of the terms above are unclear to you (e.g. _staking_ vs _locking_) you can find detailed exaplanation the following sections:
+
+- [Tokenomics 2.0](/docs/learn/tokenomics2/)
+- [dApp Staking v3 Technical Overview](/docs/learn/dapp-staking-v3/dapp-staking-protocol.md)
+
+### Practical explanation with an example:
+
+Locking tokens means they become eligible to be used for dApp staking. This is similar (or same) as before in v2. Locked tokens cannot be used to pay transaction fees, cannot be sent to other accounts, etc.
+
+In v2, both _locking_ & _staking_ were a single action (_stake_) but in v3 they are split. Once v3 is deployed, all stakes (TVL) will be migrated to locked state within dApp Staking.
+
+This means if `Alice` was _staking_ on dApp `DAPP_1` 3000 ASTR, after the migration, `Alice` will have 3000 ASTR _locked_. But these 3000 ASTR won’t be _staked_ on anything. Instead, `Alice` will need to decide what to stake on (maybe on dApp `DAPP_1` again) and do the 2nd step - _stake_ action.
+
+In case she doesn’t want to stake anymore, she can _unlock_, which is similar to the old _unbond&unstake_ and wait for the unlocking period to pass (roughly 10 days) before these funds can be freely used again (e.g. transfer to someone else).
+
+No stakes are getting carried over, but all TVL is getting carried over.
+
+### Q: What About Unclaimed Rewards?
+Once v3 is launched, all of the unclaimed v2 rewards will become inaccessible. It doesn’t make sense to migrate rewards since the new [Tokenomics 2.0](/docs/learn/tokenomics2/) are tightly coupled with dApp staking - e.g. it’s not really possible to guarantee any inflation rate if we allow minting of over 2 year old rewards.
+
+To prevent users from loosing long accumulated rewards, a special state will be introduced into v2: **Decommission Mode**. Once decommissioning has started, majority of the dApps staking v2 functionality will be disabled, with the exception of reward claim calls. Two new special calls will also become available - _delegated staker reward claim_ & _delegated reward destination setting_.
+
+Using the new delegated calls, anyone will be able to claim rewards for anyone else. E.g. `Alice` can claim rewards for `Bob` - this essentially means that `Alice` pays for the transaction fee to claim `Bob's`. Of course, `Bob's` rewards are deposited into his account, not `Alice's` :slightly_smiling_face:.
+
+Astar team will ensure that all pending rewards are claimed during the decommissioning. We won’t launch v3 until all unclaimed rewards have been claimed.
+
+These transactions won’t be _free_, and whoever runs the _claim bot_ will need to be reimbursed by the treasury - but this is another topic. **TODO - please refer here for more info.**
+
+Please do your best to claim the rewards yourself, and encourage others to do the same. This is just a one time thing, and won’t be something used again in dApp staking v3. Everyone is responsible for claiming their own rewards - also, with the new periods system, stakers will need to claim rewards & stake again roughly every 3 months to continue earning rewards.
+
+
+### Q: I am a Leger Astar Native App User, what do I need to do?
+
+:::danger
+For Ledger users who use the native account ([Astar Native App](https://support.ledger.com/hc/en-us/articles/10971402968733-Astar-ASTR)), dApp staking v3 will be temporarily unavailable.
+:::
+
+This is due to how Ledger app works & what is currently being developed.
+
+Ledger users will still be able to withdraw funds from dApp staking, they only won’t be able to stake & claim rewards in the new protocol version.
+
+**Why this limitation?**
+Ledger is currently developing a new generic app for all Polkadot/Kusama parachains, and that should be available soon (within months). Once that’s available, Ledger native users will be able to participate in dApp staking v3.
+
+**What can I do right now?**
+If you wish to actively participate in dApp Staking v3 right from the start, you should start the unboding period right now and move your funds to either Astar EVM Account supported by Ledger (see below) or alernatively move funds to a hot wallet.
+
+:::info 
+It is possible that by the launch of dApp staking v3, Ledger generic app will be launched, completely removing this limitation.
+:::
+
+### Q: I am a Leger Astar EVM App User, what do I need to do?
+All users using Astar EVM Ledger App ([Astar EVM](https://support.ledger.com/hc/en-us/articles/5555310160669-Astar-EVM-ASTR)) users, there are not limitations moving to dApp Staking v3. You will be able to participate in dApp staking v3 immediately.
+
+
+### Q: We are a dApp participating in dAppStaking v2, What do we need to do?
+
+Go here 
+
+
+### Still got a question?
+
+ Ask us a question via [Discord](https://discord.com/invite/astarnetwork) or [Stack Exchange](https://substrate.stackexchange.com/questions/tagged/astar) (please use tag Astar).

--- a/docs/learn/dapp-staking-v3/dapp-staking-faq.md
+++ b/docs/learn/dapp-staking-v3/dapp-staking-faq.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3
+sidebar_position: 2
 title: FAQs related to dAppStaking v3
 sidebar_label: dApp Staking FAQ
 ---
@@ -35,18 +35,17 @@ In case she doesn’t want to stake anymore, she can _unlock_, which is similar 
 No stakes are getting carried over, but all TVL is getting carried over.
 
 ### Q: What About Unclaimed Rewards?
-Once v3 is launched, all of the unclaimed v2 rewards will become inaccessible. It doesn’t make sense to migrate rewards since the new [Tokenomics 2.0](/docs/learn/tokenomics2/) are tightly coupled with dApp staking - e.g. it’s not really possible to guarantee any inflation rate if we allow minting of over 2 year old rewards.
+Once v3 is launched, all of the unclaimed v2 rewards will become inaccessible. Please do your best to claim the rewards yourself, and encourage others to do the same.
 
-To prevent users from loosing long accumulated rewards, a special state will be introduced into v2: **Decommission Mode**. Once decommissioning has started, majority of the dApps staking v2 functionality will be disabled, with the exception of reward claim calls. Two new special calls will also become available - _delegated staker reward claim_ & _delegated reward destination setting_.
+However, to prevent users from loosing long accumulated rewards, a special state will be introduced into v2: **Decommission Mode** during which it will be possible that someone else can claim other stakers' rewards (and pay fees).
 
-Using the new delegated calls, anyone will be able to claim rewards for anyone else. E.g. `Alice` can claim rewards for `Bob` - this essentially means that `Alice` pays for the transaction fee to claim `Bob's`. Of course, `Bob's` rewards are deposited into his account, not `Alice's` :slightly_smiling_face:.
+Example: Using the special calls, anyone will be able to claim rewards for anyone else. E.g. `Alice` can claim rewards for `Bob` - this essentially means that `Alice` pays for the transaction fee to claim `Bob's`. Of course, `Bob's` rewards are deposited into his account, not `Alice's`.
 
 Astar team will ensure that all pending rewards are claimed during the decommissioning. We won’t launch v3 until all unclaimed rewards have been claimed.
 
-These transactions won’t be _free_, and whoever runs the _claim bot_ will need to be reimbursed by the treasury - but this is another topic. **TODO - please refer [here](https://forum.astar.network/t/dapp-staking-migration-from-v2-to-v3/5807) for more info.**
-
-Please do your best to claim the rewards yourself, and encourage others to do the same. This is just a one time thing, and won’t be something used again in dApp staking v3. Everyone is responsible for claiming their own rewards - also, with the new periods system, stakers will need to claim rewards & stake again roughly every 3 months to continue earning rewards.
-
+:::info
+Please refer to [this Astar Forum discssion](https://forum.astar.network/t/dapp-staking-migration-from-v2-to-v3/5807) for all the details regarding unclaimed rewards.
+:::
 
 ### Q: I am a Leger Astar Native App User, what do I need to do?
 
@@ -66,6 +65,8 @@ If you wish to actively participate in dApp Staking v3 right from the start, you
 
 :::info 
 It is possible that by the launch of dApp staking v3, Ledger generic app will be launched, completely removing this limitation.
+
+Keep an eye out on this page and official announcements for more info as it becomes available.
 :::
 
 ### Q: I am a Leger Astar EVM App User, what do I need to do?

--- a/docs/learn/dapp-staking-v3/dapp-staking-faq.md
+++ b/docs/learn/dapp-staking-v3/dapp-staking-faq.md
@@ -43,7 +43,7 @@ Using the new delegated calls, anyone will be able to claim rewards for anyone e
 
 Astar team will ensure that all pending rewards are claimed during the decommissioning. We won’t launch v3 until all unclaimed rewards have been claimed.
 
-These transactions won’t be _free_, and whoever runs the _claim bot_ will need to be reimbursed by the treasury - but this is another topic. **TODO - please refer [here](https://forum.astar.network/t/dapp-staking-migration-from-v2-to-v3/5807?u=gaius_sama) for more info.**
+These transactions won’t be _free_, and whoever runs the _claim bot_ will need to be reimbursed by the treasury - but this is another topic. **TODO - please refer [here](https://forum.astar.network/t/dapp-staking-migration-from-v2-to-v3/5807) for more info.**
 
 Please do your best to claim the rewards yourself, and encourage others to do the same. This is just a one time thing, and won’t be something used again in dApp staking v3. Everyone is responsible for claiming their own rewards - also, with the new periods system, stakers will need to claim rewards & stake again roughly every 3 months to continue earning rewards.
 

--- a/docs/learn/dapp-staking-v3/dapp-staking-faq.md
+++ b/docs/learn/dapp-staking-v3/dapp-staking-faq.md
@@ -74,7 +74,7 @@ All users using Astar EVM Ledger App ([Astar EVM](https://support.ledger.com/hc/
 
 ### Q: We are a dApp participating in dAppStaking v2, What do we need to do?
 
-Go here 
+Inform your community and stakers that they should be active once dApp Staking v3 goes live and support your project by staking.
 
 
 ### Still got a question?

--- a/docs/learn/dapp-staking-v3/dapp-staking-protocol.md
+++ b/docs/learn/dapp-staking-v3/dapp-staking-protocol.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 2
+sidebar_position: 1
 title: dApp Staking v3 Technical overview
 ---
 

--- a/docs/learn/dapp-staking-v3/dapp-staking-protocol.md
+++ b/docs/learn/dapp-staking-v3/dapp-staking-protocol.md
@@ -1,0 +1,317 @@
+---
+sidebar_position: 11
+title: dApp Staking
+toc_max_heading_level: 3
+---
+
+## Introduction
+
+Astar and Shiden networks provide a unique way for developers to earn rewards by developing products that native token holders can decide to support.
+
+The principle is simple - stakers _lock_ their tokens to _stake_ on a dApp, and if the dApp attracts enough support, it is rewarded in native currency, derived from the inflation.
+In turn stakers are rewarded for locking & staking their tokens.
+
+The following chapters will provide an overview of the functionality and terminology with accompanying examples.
+
+## Functionality Overview
+
+### Eras
+
+Eras are the basic _time unit_ in dApp staking and their length is measured in the number of blocks.
+
+Eras are not expected to last long, e.g. current production networks era length is roughly 1 day (7200 blocks).
+After an era ends, it's usually possible to claim rewards for it, if staker or dApp are eligible.
+
+### Periods
+
+Periods are another _time unit_ in dApp staking. They are expected to be more lengthy than eras.
+Each period is denoted by a number, e.g. **1**, which increments each time a new period begins.
+
+Each period consists of two subperiods:
+* `Voting`
+* `Build&Earn`
+
+Period beginning is marked by the `Voting` subperiod, after which follows the `Build&Earn` subperiod.
+
+Stakes are **only** valid throughout a period. When new period starts, all stakes are reset to **zero**. Protocol dynamic prevents inactive projects having high stakes due to inertia of stakers while at the same time allows more visibility for dApps joining the protocol and equal chance in attracting stakers' attention.
+
+Even though stakes are reset, locks (or freezes) of tokens remain.
+
+#### Voting Subperiod
+
+When `Voting` subperiod starts, all _stakes_ are reset to **zero**.
+Projects participating in dApp staking are expected to market themselves to (re)attract stakers.
+
+Stakers must assess whether the project they want to stake on brings value to the ecosystem, and then `vote` for it (or _stake_ on it).
+Casting a vote, or staking, during the `Voting` subperiod makes the staker eligible for bonus rewards. so they are encouraged to participate during this time.
+
+`Voting` subperiod length is expressed in _standard_ era lengths, even though the entire voting subperiod is treated as a single _voting era_.
+E.g. if `Voting` subperiod lasts for **5 eras**, and each era lasts for **100 blocks**, total length of the `Voting` subperiod will be **500** blocks **BUT** it will consume only a single numeric era:
+* Block 1, Era 1 starts, Period 1 starts, `Voting` subperiod starts
+* Block 501, Era 2 starts, Period 1 continues, `Build&Earn` subperiod starts
+
+Neither stakers nor dApps earn rewards during the `Voting` subperiod; rewards are only generated for eras in the `Build&Earn` subperiod. However, as mentioned before, it’s crucial for dApps to use this time to market themselves and attract stakers, and for stakers to assess which projects they want to support.
+
+It is important to award projects which the staker believes will bring value to the network and possibly themselves.
+Voting on a poor project means that poor performance is rewarded, damaging the network instead of improving it.
+
+#### Build&Earn
+
+`Build&Earn` subperiod consists of one or more eras.
+E.g. if `Build&Earn` subperiod lasts for **10 eras**, and each era lasts for **100 blocks**, these **10 eras** would consume **1000 blocks** in total.
+
+After each _era_ ends, eligible stakers and dApps can claim the rewards they earned.
+
+Rewards are **only** claimable for the finished eras.
+E.g. if the **era 3** is ongoing, staker can claim rewards for **era 2** if they were eligible.
+
+Staker is **only** eligible for rewards **if** they have been staking for the entire era. E.g. if staker stakes in **era 2**, they are only eligible for rewards
+from **era 3**, which can be claimed from **era 4** onwards.
+
+Even though `Build&Earn` comes after the `Voting`, it is still possible to _stake_ during this period, and stakers are encouraged to do so
+since this will increase the staker rewards they earn.
+The only exemption is the **final era** of the `Build&Earn` subperiod - it's not possible to _stake_ then since the stake would be invalid anyhow (stake is only valid from the next era which would be in the next period when all stakes are reset to _zero_).
+
+To continue the previous example where era length is **100** blocks, let's assume that `Build&Earn` subperiod lasts for 10 eras:
+* Block 1, Era 1 starts, Period 1 starts, `Voting` subperiod starts
+* Block 501, Era 2 starts, Period 1 continues, `Build&Earn` subperiod starts
+* Block 601, Era 3 starts, Period 1 continues, `Build&Earn` subperiod continues
+* Block 701, Era 4 starts, Period 1 continues, `Build&Earn` subperiod continues
+* ...
+* Block 1401, Era 11 starts, Period 1 continues, `Build&Earn` subperiod enters the final era
+* Block 1501, Era 12 starts, Period 2 starts, `Voting` subperiod starts
+* Block 2001, Era 13 starts, Period 2 continues, `Build&Earn` subperiod starts
+
+### dApps & Smart Contracts
+
+#### Registration
+
+Projects, or _dApps_, must be registered into protocol to participate.
+Only a privileged origin can perform dApp registration.
+At the moment of writing this, dApps & projects can request to be registered via Astar's forum.
+
+Once the dApp has been registered, stakers can stake on it immediately, and it can earn rewards from the era in which it was registered.
+
+There is a limit of how many smart contracts can be registered at once. Once the limit is reached, any additional attempt to register a new contract will fail.
+This puts an upper bound on how many contracts the protocol can support.
+
+#### Reward Beneficiary & Ownership
+
+After a dApp has been registered, it is possible to modify reward beneficiary or even the owner of the dApp. The owner can perform reward delegation and can further transfer ownership.
+
+This is useful if dApp owners want to deposit rewards and/or transfer ownership to a DAO or a multisig account.
+
+#### Unregistration
+
+dApp can be removed from the protocol by unregistering it.
+This is an action that can only be done by a privileged origin.
+Unregistration can be the result of bad performance, reorganization or any other reason
+which governance decides it's viable.
+
+After a dApp has been unregistered, it's no longer eligible to receive rewards.
+It's still possible however to claim past unclaimed rewards.
+
+Important to note that even if dApp has been unregistered, it still occupies a _slot_
+in the dApp staking protocol and counts towards maximum number of registered dApps.
+This will be improved in the future when dApp data will be cleaned up after some time.
+
+### Stakers
+
+#### Locking Tokens
+
+In order for users to participate in dApp staking, the first step they need to take is lock (or freeze) some native currency. Reserved tokens cannot be locked, but tokens locked by another lock can be re-locked into dApp staking (double locked).
+
+This is useful for _vested_ tokens, which although cannot be transferred to another account, can still be used to participate in dApp staking.
+
+:::note
+Locked funds **NEVER** leave the staker's wallet - it's only not possible to use those funds for fee payment or for transfer.
+:::
+
+In order to participate, user must have a `MinimumLockedAmount` of native currency locked. This doesn't mean that they cannot lock _less_ in a single call, but total locked amount must always be equal or greater than `MinimumLockedAmount`.
+
+E.g. if an account isn't participating in dApp staking and threshold is set to **10 ASTR**, attempting to lock **9 ASTR** will fail.
+However, if user already has **10 ASTR** locked, they can safely lock an additional **1 ASTR**, for **11 ASTR locked in total.
+
+In case amount specified for locking is greater than what user has available, only what's available will be locked - it's not possible to lock more than what's available.
+
+Once tokens have been locked, they can be used to stake immediately.
+Users should ensure to do so since _locking_ doesn't bring any rewards, unless tokens are staked as well.
+
+#### Unlocking Tokens
+
+User can at any time decide to unlock their tokens. However, it's not possible to unlock tokens which are staked, so user has to unstake them first.
+
+After _unlock_ is successfully executed, the tokens aren't immediately unlocked, but instead must undergo the unlocking process.
+This process takes a predefined amount of blocks to finish. This is a well known & widely used mechanism to reduce selling pressure.
+
+Once unlocking process has finished, user can _claim_ their unlocked tokens into their free balance.
+
+There is a limited number of `unlocking chunks` a user can have at any point in time. If limit is reached, user must claim existing unlocked chunks, or wait for them to be unlocked before claiming them to free up space for new chunks. This mechanism exists simply to prevent users from creating unlimited amounts of chunks in storage.
+
+In case unlocking some amount would take the user below the `MinimumLockedAmount`, **everything** will be unlocked.
+E.g. if minimum locked amount is set to **10 ASTR**, user has **15 ASTR** locked, and they decide tu _unlock_ **6 ASTR**, this would take them to **9 ASTR** which is below threshold. As a result, all **15 ASTR** will be unlocked.
+
+In case users would like to re-lock the _unlocking chunks_ back into the dApp staking protocol, they can easily do that, without having to wait for the unlocking process
+to finish.
+
+#### Staking Tokens
+
+Locked tokens, which aren't being used for staking, can be used to stake on a dApp. This translates to _voting_ or _nominating_ a dApp to receive rewards derived from the inflation. User can stake on multiple dApps if they want to.
+
+The staked amount is only eligible for rewards from the next era - in other words, only the amount that has been staked for the entire era is eligible to receive rewards.
+E.g. if user had staked **15 ASTR** in **era 5** on a dApp, and decides to stake an additional **5 ASTR**, the new total stake amount of **20 ASTR** is only eligible for rewards from **era 6**. Assuming staker doesn't do additional changes, rewards for **era 5** will be calculated for stake amount of **15 ASTR**, while rewards for **era 6** will be calculated for stake amount of **20 ASTR**.
+
+It is not possible to stake if there are unclaimed rewards from past eras. User must ensure to first claim their pending rewards, before staking. This is also beneficial to the users since it allows them to lock & stake the earned rewards as well.
+
+User's stake on a contract must be equal or greater than the `MinimumStakeAmount`. This is similar to the minimum lock amount, but this limit is per contract.
+Although user can stake on multiple smart contracts, the amount is limited. To be more precise, amount of database entries that can exist per user is limited.
+This should not be a problem in practice though.
+
+The protocol keeps track of how much was staked by the user in the `Voting` and `Build&Earn` subperiods. This is important for the bonus reward calculation.
+
+It is not possible to stake on a dApp that has been unregistered.
+However, if dApp is unregistered after user has staked on it, user will keep earning
+rewards for the staked amount.
+
+#### Unstaking Tokens
+
+User can at any time decide to unstake staked tokens. There's no _unstaking_ process associated with this action.
+However, unstaking some amount forfeits it from being included in the reward calculation for that era - this is why it's important
+to choose staked dApps carefully.
+
+Unlike stake operation, which stakes from the _next_ era, unstake will reduce the staked amount for the current and next era if stake exists.
+
+Same as with stake operation, it's not possible to unstake anything until unclaimed rewards have been claimed. User must ensure to first claim all rewards, before attempting to unstake.
+
+The amount unstaked will always first reduce the amount staked in the ongoing subperiod. E.g. if `Voting` subperiod has stake of **100 ASTR**, and `Build&Earn` subperiod has stake of **50**, calling unstake with amount of **70 ASTR** during `Build&Earn` subperiod will see `Build&Earn` stake amount reduced to **zero**, while `Voting` stake will be reduced to **80**.
+
+If unstake would reduce the staked amount below `MinimumStakeAmount`, everything is unstaked.
+
+Once period finishes, all stakes are reset back to zero. This means that no unstake operation is needed after period ends to _unstake_ funds - it's done automatically.
+
+#### Claiming Staker Rewards
+
+Stakers can claim rewards for passed eras during which they were staked for the entire duration of the era.
+Even if multiple contracts were staked, claim reward call will claim rewards for all of them.
+
+Only rewards for the finished eras can be claimed. It is possible to claim rewards for multiple eras using a single call. This can happen if staker hasn't claimed rewards in some time, and many eras have passed since then, accumulating pending rewards. There is a limit on how many rewards can a single call claim, so if a lot of rewards have accumulated, it's possible that multiple claim calls will be required to claim all of the pending rewards.
+
+Rewards don't remain available forever, and if not claimed within some time period, they will be treated as expired. This will be a longer period, but will still exist.
+
+Rewards are calculated using a simple formula:
+
+$staker\_reward = \frac{staker\_reward\_pool * staker\_staked\_amount}{total\_staked\_amount}$
+
+#### Claiming Bonus Reward
+
+If staker staked on a dApp during the `Voting` subperiod, and didn't reduce their staked amount below what was staked at the end of the `Voting`` subperiod, this makes them eligible for the bonus reward.
+
+E.g. if staker had staked **10 ASTR** during the `Voting` subperiod, once `Build&Earn` subperiod starts, they can stake & unstake as much as they want as long as they don't reduce the `Voting` subperiod stake below **10 ASTR**.
+It is ok to stake an additional **30 ASTR**, and then unstake **5 ASTR**, because such order of operations would leave the staker with **10 ASTR** staked in the `Voting` subperiod & **25 ASTR** staked in the `Build&Earn` subperiod.
+However, if user was to stake an additional **30 ASTR** in the `Build&Earn` subperiod, but would unstake **31 ASTR**, this would put the stake amount in `Build&Earn` subperiod to **zero**, and reduce `Voting` subperiod stake amount to **9 ASTR**. This would mean user is no longer eligible for the bonus rewards.
+
+Bonus rewards need to be claimed per contract, unlike staker rewards.
+
+Bonus reward is calculated using a simple formula:
+
+$bonus\_reward = \frac{bonus\_reward\_pool * staker\_voting\_subperiod\_stake}{total\_voting\_subperiod\_stake}$
+
+### Developers
+
+Main thing for developers to do is develop a good product & attract stakers to stake on them.
+
+#### Claiming dApp Reward
+
+If at the end of a `Build&Earn` subperiod era dApp has high enough score (support) to enter a reward tier, it will get rewards assigned to it.
+Rewards aren't paid out automatically but must be claimed instead, similar to staker & bonus rewards.
+
+dApp reward is calculated based on the tier in which ended. All dApps that end up in one tier will get the exact same reward.
+
+### Tier System
+
+At the end of each `Build&Earn` subperiod era, dApps are evaluated using a simple metric - total value staked on them.
+Based on this metric, they are sorted, and assigned to tiers.
+
+There is a predefined limited number of tiers, and each tier has a limited capacity of slots.
+Each tier also has a _threshold_ which a dApp must satisfy in order to enter it.
+
+#### Tiers Capacity
+
+There is a limited amount of slots for dApps which means dApps have to compete for them.
+The amount isn't static but is recalculated at the start of each period.
+
+Since the purpose of dApp staking isn't for dApps to earn obscene amounts of rewards, but to provide
+basic income, number of slots is scaled with the value of **ASTR** expressed in **USD**.
+
+At the beginning of each period, using the average **ASTR** price during the former period, new number of slots is calculated:
+
+$ number\_of\_slots = floor(1000 + ASTR_{USD} + 50)$
+
+This approach means that as **ASTR** value increases, so does the number of slots for dApp staking, and vice-versa.
+
+Once number of slots is calculated, it is divided up into slots per tier.
+The portions are statically configured, e.g. _tier 1_ gets **10%** of the slots, _tier 2_ gets **25%** of the slots, and so on.
+
+#### Tier Threshold Entry
+
+A dApp isn't entitled to a tier by just participating in the dApp Staking.
+It needs to attract sufficient support to even be eligible for entry into a tier.
+
+E.g. a threshold to enter _tier 1_ might be set to **1,000,000 ASTR**.
+Since number of slots is dynamic, so has to be the threshold to allow for more realistic competition.
+It's not fair to define the same threshold for entering a tier if there are 50 slots or 500 slots since the
+staked amount will be more diluted between various dApps.
+
+The formula for adjusting tier entry threshold:
+
+$\Delta\%_{threshold} = (\frac{100\%}{100\% + \Delta\%_{dApps}} - 1) * 100\%$
+
+where $\Delta\%_{dApps}$ is the change in the number of dApps, expressed as a percent. In case number has been reduced, the _delta_ will be negative.
+
+At the moment, there are two types of tier entry thresholds:
+* `Dynamic` - adjusts the threshold based on the aforementioned formula.
+* `Fixed` - defines a static, fixed threshold which doesn't adapt.
+
+The `Dynamic` threshold is used for _higher_ tiers, and also defines the minimum amount to which the threshold can fall.
+E.g. a threshold might define _current_ value as **1,000,000 ASTR**. Since this can be decreased if number of slots goes up,
+it also defines a minimum amount the threshold can take, e.g. **500,000 ASTR**.
+
+The `Fixed` threshold is used for the _lowest tier_, and defines a static value.
+
+#### Tier Rewards
+
+Better tiers bring bigger rewards, so dApps are encouraged to compete for higher tiers and attract staker's support.
+dApp reward pool is divided between tiers, e.g. _tier 1_ gets **40%** of the total reward pool, and the assigned tier reward pool
+is further divided between the dApps in the pool.
+
+This means that each dApp within a tier always gets the same amount of reward.
+Even if tier capacity hasn't been fully taken, rewards are paid out as if they were.
+
+For example, if _tier 1_ has capacity for 10 dApps, and reward pool is **500 ASTR**, it means that each dApp that ends up
+in this tier will earn **50 ASTR**. Even if only 3 dApps manage to enter this tier, they will still earn each **50 ASTR**.
+The rest, **350 ASTR** in this case, won't be minted.
+
+#### More On Tiers
+If there are more dApps eligible for a tier than there is capacity, the dApps with the higher score get the advantage.
+dApps which missed out on a higher tier get priority for entry into the next lower tier (if there still is any).
+
+In the case a dApp doesn't satisfy the entry threshold for any tier, even though there is still capacity, the dApp will simply
+be left out of tiers and won't earn **any** reward.
+
+In a special and unlikely case that two or more dApps have the exact same score and satisfy tier entry threshold, but there isn't enough
+leftover tier capacity to accommodate them all, this is considered _undefined_ behavior. Some of the dApps will manage to enter the tier, while
+others will be left out. There is no strict rule which defines this behavior - instead dApps are encouraged to ensure their tier entry by
+having a larger stake than the other dApp(s). Technically, at the moment, the dApp with the lower `dApp Id` will have the advantage over a dApp with
+the larger Id but this can change in the future.
+
+### Reward Expiry
+
+Unclaimed rewards aren't kept indefinitely in storage. Eventually, they expire.
+Stakers & developers should make sure they claim those rewards before this happens.
+
+In case they don't, they will simply miss on the earnings.
+
+However, this should not be a problem given how the system is designed.
+There is no longer _stake&forget_ - users are expected to revisit dApp staking at least at the
+beginning of each new period to pick out old or new dApps on which to stake on.
+If they don't do that, they miss out on the bonus reward & won't earn any staker rewards.

--- a/docs/learn/dapp-staking-v3/dapp-staking-protocol.md
+++ b/docs/learn/dapp-staking-v3/dapp-staking-protocol.md
@@ -1,7 +1,6 @@
 ---
-sidebar_position: 11
-title: dApp Staking
-toc_max_heading_level: 3
+sidebar_position: 2
+title: dApp Staking v3 Technical overview
 ---
 
 ## Introduction

--- a/docs/learn/dapp-staking-v3/index.md
+++ b/docs/learn/dapp-staking-v3/index.md
@@ -1,0 +1,62 @@
+---
+sidebar_position: 1
+title: dApp Staking overview
+---
+
+# dApp Staking
+
+## What is dApp Staking
+
+On the Astar/Shiden Network, developers who build decentralized applications (dApps) have the opportunity to receive compensation through a process known as dApp staking. By engaging in dApp staking, developers can receive a basic income, which allows them to continue building and enhancing their dApps.
+
+dApp staking on the Astar/Shiden Network operates similarly to staking on validators. However, in this new paradigm, individuals known as dApp stakers or nominators have the ability to nominate their Astar/Shiden tokens on specific dApps they wish to support.
+
+At every block on the network, a portion of the rewards is allocated to dApp staking. This reward is then distributed between the operators (developers) of the dApps and the nominators. This mechanism serves as a powerful incentive for developers to build and deploy their dApps on the Astar/Shiden Network.
+
+
+## Benefits of dApp Staking on Astar/Shiden
+
+For Web3 to flourish, there needs to be a symbiotic relationship between dApp stakers (i.e. nominators), dApp developers, and dApp users. On Astar/Shiden, dApp staking is the mechanism that enables this mutually beneficial relationship to occur.
+
+- Developer Compensation: Unlike traditional approaches where dApp developers need to rely on grant programs, token issuance, and fundraising efforts to generate income, dApp staking on Astar/Shiden provides developers with a basic income. As long as a dApp has been nominated, developers can receive a steady stream of rewards.
+
+- Increased Popularity, Increased Reward: As a dApp gains popularity and attracts more nominators from the community, the developers who built the dApp can receive a larger percentage of the block rewards. This incentivizes developers to create high-quality dApps that resonate with users and foster community engagement.
+
+- Reduced Dependency on Gas Fees: Building on other blockchains often entails paying substantial gas fees for transactions and interactions. However, on the Astar/Shiden Network, developers can receive compensation through dApp staking, minimizing their reliance on gas fees and making it more economically feasible to continue dApp development.
+
+### Benefits for Stakers (Nominators): Increase in Token Value & High APRs
+
+Astar/Shiden dApp stakers (i.e. nominators) want the value of their tokens to increase but for the value of their tokens to increase, the underlying value of the asset — the Astar/Shiden Network — needs to increase.
+
+Another way for the value of tokens to increase is if the total circulation of tokens decreases. The more tokens are staked, the fewer tokens are in circulation, and the fewer tokens are in circulation, the higher the price.
+
+This market dynamic enables dApp stakers to get more long-term value from their tokens while earning high APRs from staking their tokens to dApps.
+
+Please refer to [this section](/docs/build/dapp-staking/for-stakers/) to learn more about participating as a staker.
+
+### Benefits for Builders: Build2Earn
+
+For great dApps to be built, developers need to build them. For developers to build great dApps, they need financial incentives.
+
+Ultimately, the most precious human resource in the Web3 ecosystem is developers. Before dApp staking, there were little to no financial incentives for developers to make dApps or to build infrastructure in public blockchains.
+
+With dApp staking, developers can earn a basic income while building dApps on Astar/Shiden. Having financial incentives entices more developers to build and improve their dApps. The more developers build on our ecosystem, the better off everyone is.
+
+Please refer to [this section](/docs/build/dapp-staking/for-devs/) to learn more about participating as a dApp builder.
+
+### Benefits for dApp Users: Increase in dApp & Network Utility
+
+For users, dApp staking enables the ecosystem to grow and improve in terms of its utility. This is because better dApps are built as a result of developers having a way to earn money while building them.
+
+Having more (and better) dApps attracts and retains more users, creating a network effect, which helps to grow the ecosystem and increases the long-term intrinsic value of the network.
+
+
+## What next?
+
+If you are ASTR token holder interested in staking please refer to [this section](/docs/build/dapp-staking/for-stakers/) to learn more about participating as a staker.
+
+If you are a dApp developer building on Astar, please refer to [this section](/docs/build/dapp-staking/for-stakers/) to learn more about participating as a staker.
+
+For detailed technical overview of dAppStaking protocol please go [here](/docs/learn/dapp-staking-v3/dapp-staking-protocol.md)
+
+Still have a question? - check this FAQ specific to dAppStaking v3 planned to go live on Astar in Q1 2024.

--- a/docs/learn/dapp-staking-v3/index.md
+++ b/docs/learn/dapp-staking-v3/index.md
@@ -34,11 +34,11 @@ This market dynamic enables dApp stakers to get more long-term value from their 
 
 Please refer to [this section](/docs/build/dapp-staking/for-stakers/) to learn more about participating as a staker.
 
-### Benefits for Builders: Build2Earn
+### Benefits for Builders: Earn Rewards
 
 For great dApps to be built, developers need to build them. For developers to build great dApps, they need financial incentives.
 
-Ultimately, the most precious human resource in the Web3 ecosystem is developers. Before dApp staking, there were little to no financial incentives for developers to make dApps or to build infrastructure in public blockchains.
+Ultimately, the most precious human resource in the Web3 ecosystem are developers. Before dApp staking, there were little to no financial incentives for developers to make dApps or to build infrastructure in public blockchains.
 
 With dApp staking, developers can earn a basic income while building dApps on Astar/Shiden. Having financial incentives entices more developers to build and improve their dApps. The more developers build on our ecosystem, the better off everyone is.
 

--- a/docs/learn/index.md
+++ b/docs/learn/index.md
@@ -29,4 +29,4 @@ To expand your knowledge about building applications or utilizing various tools 
 
 [zkEVM](/docs/learn/zkEVM)
 
-[dApp Staking](/docs/learn/dapp-staking.md)
+[dApp Staking](/docs/learn/dapp-staking-v3)


### PR DESCRIPTION
Based on this issue #558 

I did not change nomenclature (e.g. build2ear) but moved forward to
- add relevant info about dappstaking v3 in LEARN section
- remove build2earn from LEARN section (redundant)

TODO in future PR
- update BUILD section (Decide what is redundant) and update naming convetntion

File docs/learn/dapp-staking.md is verbatim copied to docs/learn/dapp-staking-v3/dapp-staking-protocol.md

