### PR TITLE
Update: openbrush tag correction

### DIFF
--- a/docs/tutorials/from-zero-to-ink-hero/nft/Wizard/wizard.md
+++ b/docs/tutorials/from-zero-to-ink-hero/nft/Wizard/wizard.md
@@ -82,7 +82,7 @@ edition = "2021"
 ink = { version = "4.2.1", default-features = false }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2.6", default-features = false, features = ["derive"], optional = true }
-openbrush = { tag = "v4.0.0-beta", git = "https://github.com/Brushfam/openbrush-contracts", default-features = false, features = ["psp34", "ownable"] }
+openbrush = { tag = "4.0.0-beta", git = "https://github.com/Brushfam/openbrush-contracts", default-features = false, features = ["psp34", "ownable"] }
 
 [lib]
 path = "lib.rs"


### PR DESCRIPTION
**Pull Request Summary**

Modification of the documentation in the "tutorials" section, specifically the part covering the tutorial on PSP34 with the contract wizard. Updated the openbrush tag from "v4.0.0.0-beta" to "4.0.0-beta" which is the correct format.

**Check list**

- [ ]  contains breaking changes
- [ ]  adds new feature
- [ ]  modifies existing feature (bug fix or improvements)
- [ ]  relies on other tasks
- [x]  documentation changes
- [ ]  tested on mobile devices

**This pull request makes the following changes:**

**Modifies**

- Modify the section of the documentation covering the PSP34 tutorial with contract wizard by updating the openbrush tag to the correct format.