### PR TITLE
Update zkEVM-guides for JP

### DIFF
--- a/i18n/ja/docusaurus-plugin-content-docs/current/use/zkevm-guides/ASTR-Liquid-Staking.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/use/zkevm-guides/ASTR-Liquid-Staking.md
@@ -1,0 +1,79 @@
+---
+sidebar_position: 4
+title: ASTR Liquid dApp Staking
+---
+
+import Figure from "/src/components/figure"
+
+# Bifrost Finance による ASTR Liquid dApp Staking
+
+このページでは、**Astar zkEVM**上でBifrost Liquid Stakingソリューションを通じてAstar dApp Stakingに参加する方法について説明します。
+[dApp Stakingについて詳細情報](/docs/use/dapp-staking/index/)。
+
+Astar L1 (SubtrateまたはEVM)上に`ASTR`を持っている場合は、[このガイド](/docs/use/zkevm-guides/Bridge-Astar-EVM/) を参照して、それらをAstarからAstar zkEVMに転送してください。
+
+## Bifrost Finance
+
+*Astar Foundationは、当社のドキュメンテーションで紹介される第三者アプリケーションの利用により生じる直接的、間接的、偶発的、特別、結果的、または例示的な損害について、一切の責任を負わないことをご了承ください。*
+
+[Bifrost](https://bifrost.app/) は、Polkadotに基づくモジュラー型、スケーラブル、非預託型のオムニチェーンリキッドステーキングパラチェーンです。それはXCMを通じてWeb3のための標準化された、高利回り、安全で信頼性のある元本保証付き資産を提供し、任意のLSTを任意のチェーンで使用するオムニチェーンビジョンを実現しています。[詳細情報](https://docs.bifrost.finance/)。
+
+Bifrostは、その[SLPx Omichain protocol](https://omni.ls/)  (OmiLS)を介してAstar zkEVM上で利用可能であり、これはAstar EVMやAstar zkEVMなどのEVMチェーンからBifrostパラチェーンにLSDトークンを発行するクロスチェーンメカニズムを可能にします。
+
+ASTRトークンのLiquid Stakingバージョンは**vASTR** (voucher ASTR)と呼ばれ、ステーキングされたASTRのシャドウトークンで、完全な下位のASTRリザーブとASTR dApp Staking報酬の利回り特性を持っています。ユーザーはASTRをAstar zkEVM上のBifrost OmniLSプロトコルに預け、vASTRを返してもらうことができ、vASTRはオープンマーケットで取引されるか、ASTRに引き換えることができます。vASTRを保持することは、ASTRのステーキングポジションを保持することと同等で、ステーキング報酬はvASTRの交換価格を上昇させます。
+
+:::info
+ステーキング報酬に10%の手数料を課金します。
+:::
+
+## ASTRをステーキングしてvASTRを受け取る方法：
+
+1. [Bifrost OmniLS](https://omni.ls/) にアクセスし、`vASTR`を選択し、**Astar zkEVM**ネットワーク上のEVMウォレットを接続します。
+
+<Figure src={require('/docs/use/zkevm-guides/img/Bifrost_1.png').default} width="70%" />
+
+2. Liquid Stakingでステーキングしたい`ASTR`の量を入力します。その結果、ASTR/vASTRの比率に従って`vASTR`トークンを受け取ります。
+*クロスチェーン取引手数料（ステーキング額から差し引かれる）を考慮に入れてください。*
+
+<Figure src={require('/docs/use/zkevm-guides/img/Bifrost_2.png').default} width="80%" />
+
+3. `Approve`をクリックしてBifrostに資金へのアクセスを許可し、ウォレットでトランザクションに署名します。
+
+4. `Stake Now`をクリックしてトランザクションを開始し、ウォレットで署名します。
+
+<Figure src={require('/docs/use/zkevm-guides/img/Bifrost_3.png').default} width="80%" />
+
+5. トランザクションは複数のネットワーク（*Astar zkEVM、Astar EVM、Bifrost*）で行われるため、トランザクションがファイナライズされ、vASTRがウォレットに表示されるまでに**最大10分**かかることがあります。
+6. vASTRトークンを受け取ったら、それらはAstar zkEVMで使用する準備ができています。
+
+<Figure src={require('/docs/use/zkevm-guides/img/Bifrost_4.png').default} width="80%" />
+
+:::info
+手動でEVMウォレットにトークンを追加するには、以下のコントラクトアドレスを使用します。
+- **vASTR:** `0x7746ef546d562b443AE4B4145541a3b1a3D75717`
+:::
+
+## vASTRをアンステーキングしてASTRを受け取る方法：
+
+1. [Bifrost OmniLS](https://omni.ls/) にアクセスし、`vASTR`を選択し、**Astar zkEVM**ネットワーク上のEVMウォレットを接続します。
+
+<Figure src={require('/docs/use/zkevm-guides/img/Bifrost_1.png').default} width="70%" />
+
+2. **Unstake Panel**に切り替え、引き換え(償還)たい`vASTR`の量を入力します。その結果、ASTR/vASTRの比率に従って、ステーキング報酬を含む`ASTR`トークンを受け取ります。
+*クロスチェーン取引手数料（ステーキング額から差し引かれる）を考慮に入れてください。*
+
+<Figure src={require('/docs/use/zkevm-guides/img/Bifrost_5.png').default} width="90%" />
+
+3. `Approve`をクリックしてBifrostに資金へのアクセスを許可し、ウォレットでトランザクションに署名します。
+
+4. `Unstake Now`をクリックしてトランザクションを開始し、ウォレットで署名します。
+
+:::warning
+アンステーキング期間は**0日から10日**です、ご注意ください。
+:::
+
+<Figure src={require('/docs/use/zkevm-guides/img/Bifrost_6.png').default} width="90%" />
+
+5. トランザクションは複数のネットワーク（*Astar zkEVM、Astar EVM、Bifrost*）で行われるため、トランザクションがファイナライズされ、アンステーキングプロセスが開始されるまでに**最大10分**かかることがあります。
+
+6. アンステーキング期間が終了すると、あなたのASTRトークンと報酬は自動的にあなたのウォレットに届きます。

--- a/i18n/ja/docusaurus-plugin-content-docs/current/use/zkevm-guides/Bridge-Astar-EVM.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/use/zkevm-guides/Bridge-Astar-EVM.md
@@ -5,7 +5,7 @@ title: Astar EVMからAstar zkEVMへのブリッジ
 
 import Figure from "/src/components/figure"
 
-# Astar EVMからAstar zkEVMへのアセットのブリッジング
+# Astar EVMからAstar zkEVMへの資産のブリッジング
 
 このページでは、**Astar EVM**と**Astar zkEVM**間で`ASTR`を転送する方法について説明しています。
 もしAstarネイティブ（Substrate）に`ASTR`を持っている場合、AstarネイティブからAstar EVMへ転送する方法については[こちらのガイド](/docs/use/manage-assets/transfer-tokens#sending-astrsdn-to-astar-evm-from-astar-native-or-any-tokens-in-the-account)を参照してください。
@@ -16,30 +16,53 @@ import Figure from "/src/components/figure"
 
 *ご利用の皆様へ、Astar Foundationは、当社のドキュメントに記載されている第三者のアプリケーションを利用したことにより生じる直接的、間接的、偶発的、特別、結果的、または模範的な損害について、一切の責任または義務を負わないことをご了承ください。*
 
-1. [Stargate](https://stargate.finance/transfer) にアクセスし、あなたのEVMウォレットを接続してください。
+[Stargate アプリケーション](https://stargate.finance/transfer)  にアクセスし、あなたのEVMウォレットを接続してください。
 
-<Figure src={require('/docs/use/zkevm-guides/img/Stargate_1.png').default} width="70%" />
+<Figure src={require('/docs/use/zkevm-guides/img/Stargate_1.png').default} width="75%" />
 
-2. 転送したいトークンを選択し、**送信元ネットワーク**として`Astar EVM`を選択してください。
-3. 受け取りたいトークンを選択し、**送信先ネットワーク**として`Astar zkEVM`を選択してください。
-4. 転送したいトークンの量を入力し、`Transfer`をクリックして取引を確認してください。
-*ガスコストは送信先の取引のガス料金に相当し、転送される量から差し引かれます。*
+### Astar EVMからAstar zkEVMへ
 
-<Figure src={require('/docs/use/zkevm-guides/img/Stargate_2.png').default} width="60%" />
+1. 転送したいトークンを選択し、**送信元ネットワーク**として`Astar EVM`を選択してください。
+2. 受け取りたいトークンを選択し、**送信先ネットワーク**として`Astar zkEVM`を選択してください。
+3. 転送したいトークンの量を入力し、`Transfer`をクリックしてトランザクションを確認してください。
+*ガスコストは送信先のトランザクションのガス料金に相当し、転送される量から差し引かれます。*
+
+<Figure src={require('/docs/use/zkevm-guides/img/Stargate_2.png').default} width="85%" />
 
 :::tip
 Astar zkEVMでガストークン（`ETH`）をリクエストするオプションがあります。Stargateはあなたの資産の一部をETHに交換し、それをAstar zkEVMのあなたのウォレットに転送します。
 
-<Figure src={require('/docs/use/zkevm-guides/img/Stargate_3.png').default} width="95%" />
+<Figure src={require('/docs/use/zkevm-guides/img/Stargate_3.png').default} width="85%" />
 :::
 
-5. ウォレットでトランザクションに署名してください。
+4. ウォレットでトランザクションに署名します。
 
-<Figure src={require('/docs/use/zkevm-guides/img/Stargate_4.png').default} width="50%" />
+<Figure src={require('/docs/use/zkevm-guides/img/Stargate_4.png').default} width="75%" />
 
-6. ネットワーク上でトランザクションが確認されたら、EVMウォレットにブリッジされた資産が表示され、Astar zkEVMで使用する準備が整います。
+5. ネットワーク上でトランザクションが確認されたら、EVMウォレットにブリッジされた資産が表示され、Astar zkEVMで使用する準備が整います。
 
 :::info
-手動でEVMウォレットにトークンを追加するには、以下のコントラクトアドレスを使用してください:
+手動でEVMウォレットにトークンを追加するには、以下のコントラクトアドレスを使用してください。
 - **ASTR:** `0xdf41220C7e322bFEF933D85D01821ad277f90172`
 :::
+
+### Astar zkEVMからAstar EVMへ:
+
+1. 転送したいトークンを選択し、**送信元ネットワーク**には `Astar zkEVM` を選択します。
+2. 受け取りたいトークンを選択し、**送信先ネットワーク**には `Astar EVM` を選択します。
+3. 転送したいトークンの量を入力し、 `Transfer` をクリックしてトランザクションを確認します。 
+*ガスコストは送信先取引のガス料金に相当し、前払いで支払われます。*
+
+<Figure src={require('/docs/use/zkevm-guides/img/Stargate_5.png').default} width="85%" />
+
+:::tip
+Astar EVM（`ASTR`）でガストークンをリクエストするオプションがあります。Stargateはあなたの資産の一部をASTRに交換し、それをAstar EVMのあなたのウォレットに転送します。
+
+<Figure src={require('/docs/use/zkevm-guides/img/Stargate_6.png').default} width="85%" />
+:::
+
+4. ウォレットでトランザクションに署名します。
+
+<Figure src={require('/docs/use/zkevm-guides/img/Stargate_4.png').default} width="75%" />
+
+5. ネットワーク上でトランザクションが確認されると、Astar EVMで使用する準備ができたEVMウォレットにブリッジされた資産が表示されます。

--- a/i18n/ja/docusaurus-plugin-content-docs/current/use/zkevm-guides/Bridge-Ethereum.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/use/zkevm-guides/Bridge-Ethereum.md
@@ -1,53 +1,112 @@
-﻿---
+---
 sidebar_position: 2
-title: Ethereumおよび他のEVMベースのチェーンからAstar zkEVMへのブリッジ
-
-
-sidebar_label: Bridge Astar <> Ethereum
+title: Ethereum からAstar zkEVM へブリッジ
 ---
 
 import Figure from "/src/components/figure"
 
-# Ethereumおよび他のEVMベースのチェーンからAstar zkEVMへのブリッジ
+# Ethereum および他の EVM ベースのチェーンから Astar zkEVM へのブリッジ
 
-このページでは、**Astar zkEVM**と**Ethereumメインネット**および他のEVMベースのチェーン間で`ETH`および他の`ERC20`資産を転送する方法について説明します。zkEVMへの資産のブリッジには2つのオプションがあります：
+このページでは、**Astar zkEVM**と**Ethereum メインネット**および他の EVM ベースのチェーン間で`ETH`および他の`ERC20`資産を転送する方法について説明します。zkEVM への資産のブリッジには 3 つのオプションがあります。
 
-### Astar Portal を使用した転送:
+## Astar Portal を使用した転送:
 
-1. [Astar Portal](https://portal.astar.network/astar-zkevm/bridge/ethereum) にアクセスし、Astar zkEVMネットワーク上であなたのウォレットを接続します;
+1. [Astar Portal](https://portal.astar.network/astar-zkevm/bridge/ethereum) にアクセスし、Astar zkEVM ネットワーク上であなたのウォレットを接続します。
 
 <Figure src={require('/docs/use/zkevm-guides/img/Bridge_ETH_Portal_1.png').default} width="60%" />
 
-2. ネットワークモーダルウィンドウを使用してAstar zkEVMネットワークに切り替えるか、MetaMaskをAstar zkEVMに切り替えます;
+2. ネットワークモーダルウィンドウを使用して Astar zkEVM ネットワークに切り替えるか、MetaMask を Astar zkEVM に切り替えます。
 
 <Figure src={require('/docs/use/zkevm-guides/img/Bridge_ETH_Portal_2.png').default} width="70%" />
 
-3. 左側のBridgeタブをクリックし、`Native Bridge` (*ERC20*) を選択します;
+3. 左側の Bridge タブをクリックし、`Native Bridge` (_ERC20_) を選択します。
 
 <Figure src={require('/docs/use/zkevm-guides/img/Bridge_ETH_Portal_3.png').default} width="100%" />
 
-4. Ethereumがブリッジの転送元として選択され、Astar zkEVMが転送先として選択されていることを確認します;
-転送するETHの量を入力した後`Bridge`ボタンを押します;
+### EthereumからAstar zkEVMへ
+
+1. **送信元ネットワーク**として `Ethereum` が選択されていること、そして**送信先ネットワーク**として `Astar zkEVM` が選択されていることを確認します。
+転送するETHの量を入力した後、 `Bridge` ボタンを押します。
 
 <Figure src={require('/docs/use/zkevm-guides/img/Bridge_ETH_Portal_4.png').default} width="100%" />
 
-5. ウォレットでトランザクションに署名します;
+2. ウォレットでトランザクションに署名します。
+3. Astar zkEVMで使用するために、MetaMaskにブリッジされた資産が表示されます。
 
-6. これで、Astar zkEVMで使用するためのブリッジされた資産がMetaMaskに表示されます;
+<Figure src={require('/docs/use/zkevm-guides/img/Bridge_ETH_Portal_5.png').default} width="70%" />
 
-:::info 転送は、Ethereumネットワークの使用状況により、10分から30分かかることがあります。
+:::info
+転送には、Ethereumネットワークの使用状況に応じて、10分から30分かかる場合があります。
 
-トランザクションがあなたのウォレット拡張で確認されたら、Astar PortalとMetaMaskがAstar zkEVMネットワーク上のあなたの残高を更新するのに**約5-10分**かかります。
+ウォレット拡張機能でトランザクションが確認されると、Astar PortalとMetaMaskがAstar zkEVMネットワーク上での残高を更新するまでに約**5-10分**かかります。
 :::
 
-### Relay Link を使用した転送:
+### Astar zkEVMからEthereumへ
 
-2つ目のオプションは、**[Relay Link](https://www.relay.link/bridge/astar-zkevm/)** を使用することです。これは、即時で低コストのブリッジングとクロスチェーン実行を可能にするクロスチェーン決済システムです。[詳細情報](https://docs.relay.link/what-is-relay)。
+:::warning
+これは二段階のプロセスであり、Ethereumのメインネットでトークンを請求し、対応するガス料金を支払う必要があります。
+手数料をカバーするために、メインネット上に十分な `ETH` トークンを持っていることを確認してください。
+:::
 
-:::info 現時点では、Relay Linkはクロスチェーン転送に対して**ETHトークン**のみをサポートしています！
+1. **送信元ネットワーク**として `Astar zkEVM` が選択されていること、そして**送信先ネットワーク**として `Ethereum` が選択されていることを確認します。 
+転送するETHの量を入力した後、 `Bridge` ボタンを押します。
 
-以下のチェーンからAstar zkEVMへの資産の転送が可能です:
+<Figure src={require('/docs/use/zkevm-guides/img/Bridge_ETH_Portal_6.png').default} width="100%" />
 
+2. ウォレットでトランザクションに署名します。
+3. トランザクションが送信されると、**履歴タブ**に表示されます。
+4. Ethereum上でトークンを受け取るには、 `Claim` ボタンをクリックします。
+
+<Figure src={require('/docs/use/zkevm-guides/img/Bridge_ETH_Portal_7.png').default} width="70%" />
+
+5. ウォレットでトランザクションに署名します。
+6. Ethereumで使用するために、MetaMaskにブリッジされた資産が表示されます。
+
+<Figure src={require('/docs/use/zkevm-guides/img/Bridge_ETH_Portal_8.png').default} width="70%" />
+
+:::info 転送は、Ethereum ネットワークの使用状況により、10 分から 30 分かかることがあります。
+
+トランザクションがあなたのウォレット拡張機能で確認されたら、Astar Portal と MetaMask が Astar zkEVM ネットワーク上のあなたの残高を更新するのに**約 5-10 分**かかります。
+:::
+
+## Layerswap を使用した転送:
+
+2つ目のオプションは、**[Layerswap](https://www.layerswap.io/app?to=ASTARZK_MAINNET)** を使用することです。これは、中央集権型取引所、ブロックチェーン、銀行間で暗号資産を数分で転送する信頼できるソリューションです。[詳細情報](https://docs.layerswap.io/user-docs)。
+
+
+*第三者のアプリケーションを利用することによって生じる直接的、間接的、偶発的、特別、結果的、または模範的な損害について、Astar Foundationは一切の責任を負わないことをご了承ください。*
+
+:::info
+現時点では、Layerswapはクロスチェーン転送に**ETHトークン**のみをサポートしています！
+:::
+
+1. [Layerswap](https://www.layerswap.io/app?to=ASTARZK_MAINNET)  にアクセスし、あなたのEVMウォレットを接続してください。
+
+<Figure src={require('/docs/use/zkevm-guides/img/Bridge_ETH_Layerswap_1.png').default} width="80%" />
+
+2. 資産を転送したい**送信元ネットワーク**または**中央集権型取引所**を選択し、**送信先ネットワーク**には `Astar zkEVM` を選択します。
+3. 転送したいETHの量を入力します。また、資産を送信したいアドレスも選択できます。
+
+<Figure src={require('/docs/use/zkevm-guides/img/Bridge_ETH_Layerswap_2.png').default} width="80%" />
+
+4. `Swap now` をクリックしてトランザクションを確認します。
+
+<Figure src={require('/docs/use/zkevm-guides/img/Bridge_ETH_Layerswap_3.png').default} width="80%" />
+
+5. ウォレットでトランザクションに署名します。
+6. ネットワーク上でトランザクションが確認されたら、Astar zkEVMで使用する準備ができたEVMウォレットにブリッジされた資産が表示されます。
+
+## Relay Link を使用した転送:
+
+3つ目のオプションは、**[Relay Link](https://www.relay.link/bridge/astar-zkevm/)** を使用することです。これは、即時かつ低コストでブリッジングとクロスチェーン実行を可能にするクロスチェーン決済システムです。[詳細情報](https://docs.relay.link/what-is-relay)。
+
+
+*第三者のアプリケーションを利用することによって生じる直接的、間接的、偶発的、特別、結果的、または模範的な損害について、Astar Foundationは一切の責任を負わないことをご了承ください。*
+
+:::info
+現時点では、Relay Linkはクロスチェーン転送に **ETHトークン** のみをサポートしています！
+
+以下のチェーンからAstar zkEVMへの資産転送が可能です：
 - Ethereum
 - Arbitrum
 - Optimism
@@ -56,30 +115,19 @@ import Figure from "/src/components/figure"
 - Blast
 :::
 
-1. [Relay Link](https://www.relay.link/bridge/astar-zkevm/) にアクセスし、あなたのEVMウォレットを接続します;
+1. [Relay Link](https://www.relay.link/bridge/astar-zkevm/) にアクセスし、あなたのEVMウォレットを接続してください。
 
 <Figure src={require('/docs/use/zkevm-guides/img/Bridge_ETH_Relaylink_1.png').default} width="70%" />
 
-2. 資産を転送する**元のチェーン**を選択し、**転送先チェーン**として`Astar zkEVM`を選択します;
-
-3. 転送したいETHの量を入力し、`Bridge`をクリックしてトランザクションを確認します;
+2. 資産を転送したい**送信元チェーン**を選択し、**送信先チェーン**には `Astar zkEVM` を選択します。
+3. 転送したいETHの量を入力し、 `Bridge` をクリックしてトランザクションを確認します。
 
 <Figure src={require('/docs/use/zkevm-guides/img/Bridge_ETH_Relaylink_2.png').default} width="70%" />
 
-4. ウォレットでトランザクションに署名します;
+4. ウォレットでトランザクションに署名します。
 
 <Figure src={require('/docs/use/zkevm-guides/img/Bridge_ETH_Relaylink_3.png').default} width="70%" />
 
-5. トランザクションがネットワーク上で確認されると、EVMウォレットにブリッジされた資産が表示され、Astar zkEVMで使用する準備が整います;
+5. ネットワーク上でトランザクションが確認されたら、Astar zkEVMで使用する準備ができたEVMウォレットにブリッジされた資産が表示されます。
 
 <Figure src={require('/docs/use/zkevm-guides/img/Bridge_ETH_Relaylink_4.png').default} width="70%" />
-
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
I have updated and added to the following file for the purpose of translating it into Japanese. The original file is based on the latest one located in the branch named "zKEVM-User-Guides-2".

docs-use-zkevm-guides/

- Bridge-Astar-EVM.md
- Bridge-Ethereum.md
- ASTR-Liquid-Staking.md