### PR TITLE
docs: fix typos & invalid links

### DIFF
--- a/docs/learn/Proxies.md
+++ b/docs/learn/Proxies.md
@@ -12,7 +12,7 @@ On this page, you will find a detailed overview of the various proxy types, extr
 ---
 1. **Any** - This proxy type allows delegate account to make any call that is supported by proxy pallet. This is highest level of privilege so should always use that with caution.
 
-2. **NonTransfer** - This proxy type allows delegate account to make any call supported by proxy pallet excecp for the asset transfer functionalities. This can come handy when you want to keep your funds secure in cold storage and want to delegate all the other functionalities to a proxy account.
+2. **NonTransfer** - This proxy type allows delegate account to make any call supported by proxy pallet expect for the asset transfer functionalities. This can come handy when you want to keep your funds secure in cold storage and want to delegate all the other functionalities to a proxy account.
 To see complete list of functionality, checkout the source code in Astar repo.
 
 3. **Balances** - This proxy type gives control of handling accounts and balances to the delegate account. Complete list of calls can be found [here](https://docs.rs/pallet-balances/latest/pallet_balances/pallet/enum.Call.html).

--- a/docs/learn/Proxies.md
+++ b/docs/learn/Proxies.md
@@ -10,14 +10,14 @@ On this page, you will find a detailed overview of the various proxy types, extr
 
 **Proxy Types**
 ---
-1. **Any** - This proxy type allow delegate account to make any call that are supported by proxy pallet. This is highest level of priveledge so should always use that with caution.
+1. **Any** - This proxy type allows delegate account to make any call that is supported by proxy pallet. This is highest level of privilege so should always use that with caution.
 
-2. **NonTransfer** - This proxy type allow delegate account to make any call supported by proxy pallet expect for the asset transfer funtionalities. This can come handy when you want to keep your funds secure in cold storage and want to delegate all the other functionalities to a proxy account.
+2. **NonTransfer** - This proxy type allows delegate account to make any call supported by proxy pallet excecp for the asset transfer functionalities. This can come handy when you want to keep your funds secure in cold storage and want to delegate all the other functionalities to a proxy account.
 To see complete list of functionality, checkout the source code in Astar repo.
 
 3. **Balances** - This proxy type gives control of handling accounts and balances to the delegate account. Complete list of calls can be found [here](https://docs.rs/pallet-balances/latest/pallet_balances/pallet/enum.Call.html).
 
-4. **Assets** - This proxy type allows delegate account to control the functionalities related to fungible assets which includes asset issuance, transferal, minting etc. This is to be notes that this proxy types doesn't control the native currency like Astar or Shiden which are controled by Balances proxy.
+4. **Assets** - This proxy type allows delegate account to control the functionalities related to fungible assets which includes asset issuance, transferal, minting etc. This is to be noted that this proxy types doesn't control the native currency like Astar or Shiden which are controled by Balances proxy.
 
 5. **IdentityJudgement** - This proxy type allows a single functionality to delegate account which is to provide a judgement to an identity in a naming system. The delegator must be a registrar.
 

--- a/docs/learn/Proxies.md
+++ b/docs/learn/Proxies.md
@@ -10,14 +10,14 @@ On this page, you will find a detailed overview of the various proxy types, extr
 
 **Proxy Types**
 ---
-1. **Any** - This proxy type allows delegate account to make any call that is supported by proxy pallet. This is highest level of privilege so should always use that with caution.
+1. **Any** - This proxy type allows delegate account to make any call that is supported by proxy pallet. This is the highest level of privilege so should always use that with caution.
 
 2. **NonTransfer** - This proxy type allows delegate account to make any call supported by proxy pallet expect for the asset transfer functionalities. This can come handy when you want to keep your funds secure in cold storage and want to delegate all the other functionalities to a proxy account.
 To see complete list of functionality, checkout the source code in Astar repo.
 
 3. **Balances** - This proxy type gives control of handling accounts and balances to the delegate account. Complete list of calls can be found [here](https://docs.rs/pallet-balances/latest/pallet_balances/pallet/enum.Call.html).
 
-4. **Assets** - This proxy type allows delegate account to control the functionalities related to fungible assets which includes asset issuance, transferal, minting etc. This is to be noted that this proxy types doesn't control the native currency like Astar or Shiden which are controled by Balances proxy.
+4. **Assets** - This proxy type allows delegate account to control the functionalities related to fungible assets which includes asset issuance, transferal, minting etc. This is to be noted that this proxy types doesn't control the native currency like Astar or Shiden which are controlled by Balances proxy.
 
 5. **IdentityJudgement** - This proxy type allows a single functionality to delegate account which is to provide a judgement to an identity in a naming system. The delegator must be a registrar.
 

--- a/docs/learn/accounts.md
+++ b/docs/learn/accounts.md
@@ -16,7 +16,7 @@ The private key is a cryptographically-secure sequence of randomly-generated num
 
 The address format used in Substrate-based chains like Astar is ss58. ss58 is a modification of Base-58-check from Bitcoin, with some minor modifications. Notably, the format contains an address type prefix that identifies an address as belonging to a specific network.
 
-Astar supports spezialized accounts, such as Proxy and Keyless accounts. 
+Astar supports specialized accounts, such as Proxy and Keyless accounts. 
 You can read more about Proxy accounts [here](/docs/learn/Proxies).
 
 ## EVM Accounts
@@ -25,8 +25,8 @@ Astar EVM side allows Ethereum-style addresses (H160 format), which is 40+2 hex-
 
 
 ## Learn more
-[Create a Substrate account](/docs/use/manage-wallets/create-wallet/)
+[Create a Substrate account](/docs/use/manage-wallets/create-wallet.md)
 
-[Create an EVM account](/docs/use/evm-guides/setup-metamask/)
+[Create an EVM account](/docs/use/evm-guides/setup-metamask.md)
 
 [Read about Substrate accounts](https://docs.substrate.io/learn/accounts-addresses-keys/)

--- a/docs/learn/accounts.md
+++ b/docs/learn/accounts.md
@@ -25,8 +25,8 @@ Astar EVM side allows Ethereum-style addresses (H160 format), which is 40+2 hex-
 
 
 ## Learn more
-[Create a Substrate account](/docs/use/manage-wallets/create-wallet.md)
+[Create a Substrate account](/docs/use/manage-wallets/create-wallet/)
 
-[Create an EVM account](/docs/use/evm-guides/setup-metamask.md)
+[Create an EVM account](/docs/use/evm-guides/setup-metamask/)
 
 [Read about Substrate accounts](https://docs.substrate.io/learn/accounts-addresses-keys/)

--- a/docs/learn/glossary.md
+++ b/docs/learn/glossary.md
@@ -108,7 +108,7 @@ A concept of layer 2 scaling. Modular blockchain systems move two or more of the
  A modular framework for building blockchains. Astar is built with Substrate.
 
  ### Swanky Suite 
- A suite of tools for building Wasm smart contracts on Astar that simplifly compilation, deployment and testing.
+ A suite of tools for building Wasm smart contracts on Astar that simplify compilation, deployment and testing.
 
  ### Testnet 
  Short for "test network": an experimental network where testing and development takes place. Networks are often executed on a testnet before they are deployed to a mainnet.

--- a/docs/learn/index.md
+++ b/docs/learn/index.md
@@ -10,7 +10,7 @@ To expand your knowledge about building applications or utilizing various tools 
 
 [Astar Tokens](/docs/learn/astar-tokens.md)
 
-[Account](/docs/learn/accounts.md)
+[Accounts](/docs/learn/accounts.md)
 
 [Polkadot](/docs/learn/architecture/astar-parachain.md)
 

--- a/docs/learn/index.md
+++ b/docs/learn/index.md
@@ -6,24 +6,24 @@ Whether you're an aspiring developer or a newcomer to the world of blockchain, t
 To expand your knowledge about building applications or utilizing various tools on Astar, we recommend exploring the [build](/docs/build) section. 
 
 ## Foundations
-[About Astar](/docs/learn/astar)
+[About Astar](/docs/learn/astar.md)
 
-[Astar Tokens](docs/learn/astar-tokens)
+[Astar Tokens](/docs/learn/astar-tokens.md)
 
-[Account](/docs/learn/Accounts)
+[Account](/docs/learn/accounts.md)
 
-[Polkadot](/docs/learn/architecture/astar-parachain)
+[Polkadot](/docs/learn/architecture/astar-parachain.md)
 
-[Astar zkEVM](/docs/learn/architecture/astar-zkevm)
+[Astar zkEVM](/docs/learn/architecture/astar-zkevm.md)
 
-[Smart Contracts](/docs/learn/smart-contracts)
+[Smart Contracts](/docs/learn/smart-contracts.md)
 
 [dApp Staking](/docs/learn/dapp-staking)
 
 ## Advanced 
 [Tokenomics](/docs/learn/tokenomics2)
 
-[Networks](/docs/learn/networks)
+[Networks](/docs/learn/networks.md)
 
 [Multichain Interoperability](/docs/learn/interoperability/xcm)
 

--- a/docs/learn/zkEVM/faq.md
+++ b/docs/learn/zkEVM/faq.md
@@ -76,9 +76,9 @@ Astar zkEVM is censorship resistant from the protocol level, even though in the 
         
 ### How can developers get started with building on Astar zkEVM? Are there any specific toolkits or SDKs available?
 
-See the [buid section](/docs/build/zkEVM/quickstart.md) for more about how to get started.
+See the [build section](/docs/build/zkEVM/quickstart.md) for more about how to get started.
         
-Current developers within the Astar community can benefit significantly from the expansive developer resources present in the Ethereum ecosystem where suppport and tools, including Hardhat and Truffle, are highly accessible. Eventually, Astar will introduce tools and SDKs tailored to specific Astar zkEVM functionalities.
+Current developers within the Astar community can benefit significantly from the expansive developer resources present in the Ethereum ecosystem where support and tools, including Hardhat and Truffle, are highly accessible. Eventually, Astar will introduce tools and SDKs tailored to specific Astar zkEVM functionalities.
         
 ### How does gas pricing on Astar zkEVM compare to Ethereum and Polygon?
         

--- a/docs/use/evm-guides/rescuse-lockdrop.md
+++ b/docs/use/evm-guides/rescuse-lockdrop.md
@@ -8,7 +8,7 @@ To support our users in accessing their funds, we are temporarily updating Shide
 
 ### Reconnecting Your Lockdrop Account:
 
-#### Prerequesite:
+#### Prerequisite:
 The EVM address will be used to dispatch the call on behalf of the lockdrop account. Please ensure that the **EVM address holds native tokens (ASTR or SDN) to cover gas fees** for the dispatch call.
 
 #### Steps:

--- a/docs/use/troubleshooting.md
+++ b/docs/use/troubleshooting.md
@@ -23,7 +23,7 @@ This section will guide you to troubleshoot and solve most issues when connectin
 4. If you have other extensions installed, please revoke access of those extensions.
 
 ## Getting Errors Or Unable To Execute Certain Functions;
-Some of you may be unable to execute certain funtions. Please try these steps.
+Some of you may be unable to execute certain functions. Please try these steps.
 1. Update metadata (if required).
 2. Clear cache, restart browser and connect wallet to the portal again.
 3. On the top right corner, switch to a different endpoint.
@@ -31,7 +31,7 @@ Some of you may be unable to execute certain funtions. Please try these steps.
 5. Use VPN.
 
 ## Unable To Claim Staking Rewards;
-1. If you can't claim the staking rewards on the portal. Visit [HERE](/docs/use/dapp-staking/for-stakers/manage-dApp-Staking#my-staking-panel).
+1. If you can't claim the staking rewards on the portal. Visit [HERE](/docs/use/dapp-staking/for-stakers/manage-dApp-Staking.md#my-staking-panel).
 2. If the transferrable balance in the wallet is too low, you might not be able to claim the staking rewards. Top up your wallet and then claim the rewards.
 
 ## After signing the transaction, the portal spins indefinitely;


### PR DESCRIPTION
- Fix typos and grammar correction

- Fix invalid link paths

Hope this fix helps.