### PR TITLE
Fix MetaMask setup guide: Update ASTR token name and network name

### DIFF
--- a/docs/use/evm-guides/setup-metamask.md
+++ b/docs/use/evm-guides/setup-metamask.md
@@ -26,10 +26,10 @@ Adding Astar Network to Metamask is very easy.
 Alternatively, you can also set it up manually by giving information bellow.
 <br />
 Network Details<br />
-Network Name: Astar Network Mainnet<br />
+Network Name: Astar<br />
 Network URL: https://evm.astar.network<br />
 Chain ID: 592<br />
-Currency Symbol: astr<br />
+Currency Symbol: ASTR<br />
 Block Explorer URL: https://blockscout.com/astar
 
 :::


### PR DESCRIPTION
### Summary  
This PR updates the MetaMask setup guide for Astar Network to fix issues with token and network name validation.

### Changes  
- Changed token symbol from `astr` to `ASTR` to match MetaMask requirements. (on browser extention it is almost impossible to have astr)
- Updated network name from `Astar Network Mainnet` to `Astar` to avoid validation errors.  

### Issue  
When users try to add the Astar network using the previous values on Chrome browser extension, they encounter errors in MetaMask:
- *"This token symbol doesn't match the network name or chain ID entered."*
- *"According to our records, the network name may not correctly match this chain ID."*

### Impact  
Ensures a smooth setup experience for users following the guide.  
<img width="515" alt="image" src="https://github.com/user-attachments/assets/cea87194-3927-4650-a642-c9275be5a3d9" />

