### PR TITLE
Add Krews Snapshots Section to Snapshot Documentation

### DIFF
--- a/docs/build/nodes/snapshots.md
+++ b/docs/build/nodes/snapshots.md
@@ -32,6 +32,16 @@ Note: `{BASE_PATH}` is the path specified for chain data in the node command
 * The best practice is to set it to `/var/lib/astar`
 * The default path if you don't specify any is `~/.local/share/astar-collator`
 
+## Krews snapshots usage
+
+Krews snapshots support **Astar Mainnet, Shibuya Testnet, and Shiden**, providing a faster and more stable download experience using **rclone**.  
+All snapshots are in archive mode and they do not work with pruned nodes.  
+
+Detailed information and download instructions for each snapshot are available at the links below:
+
+- **Astar Mainnet & Shibuya Testnet:** [https://krews.xyz/snapshots/astar](https://krews.xyz/snapshots/astar)  
+- **Shiden:** [https://krews.xyz/snapshots/shiden](https://krews.xyz/snapshots/shiden)
+
 ## Relay chain
 
 Since the introduction of warp sync, it is not necessary and discouraged to use a relay chain snapshot.


### PR DESCRIPTION
### **Description:**
This PR updates the **Snapshots** documentation by adding a section about **Krews snapshots**, which provide a faster and more stable way to sync Astar Mainnet, Shibuya Testnet, and Shiden nodes.

### **Changes:**
- Introduced a new **"Krews snapshots usage"** section.
- Added information about supported networks (**Astar Mainnet, Shibuya Testnet, and Shiden**).
- Included links to **Krews snapshots pages** for each network.
- Clarified that Krews snapshots use **rclone** for improved download stability.
- Ensured consistency in formatting and structure with the existing documentation.

### **Why this change?**
- Krews provides an alternative snapshot service that enhances the user experience by offering **faster downloads** and **higher stability**.
- Users can now easily access snapshots and setup instructions directly from **Krews’ snapshot dashboard**.
- This improves decentralization by providing additional snapshot sources.
- Krews snapshots are updated **daily**, making it faster for users to always have access to the latest blockchain status.

### **Relevant Links:**
- 📌 Krews Snapshots: [https://krews.xyz/snapshots/astar](https://krews.xyz/snapshots/astar), [https://krews.xyz/snapshots/shiden](https://krews.xyz/snapshots/shiden)
- 📄 Updated Documentation Page: https://github.com/AstarNetwork/astar-docs/blob/main/docs/build/nodes/snapshots.md