### PR TITLE
Migrate from Yarn PnP to node_modules and update GitHub workflows

### DIFF
--- a/.github/actions/setup-workspace/action.yml
+++ b/.github/actions/setup-workspace/action.yml
@@ -9,23 +9,18 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Setup Node.js (no cache)
-      uses: actions/setup-node@v3
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
       with:
         node-version: 22.x
+        cache: yarn
 
     - name: Enable Corepack
       run: corepack enable
       shell: bash
 
-    - name: Setup Node.js (with Yarn cache)
-      uses: actions/setup-node@v3
-      with:
-        node-version: 22.x
-        cache: yarn
-
     - name: Install dependencies with Yarn
-      run: yarn install --frozen-lockfile
+      run: yarn install --immutable
       shell: bash
 
     - name: Build project (optional)

--- a/.github/workflows/md-link-checker.yml
+++ b/.github/workflows/md-link-checker.yml
@@ -12,7 +12,7 @@ jobs:
   markdown-link-check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: gaurav-nelson/github-action-markdown-link-check@0a51127e9955b855a9bbfa1ff5577f1d1338c9a5 # 1.0.14
       with:
         use-quiet-mode: 'yes'

--- a/.github/workflows/monthly-release.yml
+++ b/.github/workflows/monthly-release.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Bump version and push tag
         id: create_tag

--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,6 @@ build/
 !.yarn/sdks
 !.yarn/versions
 .pnp.*
-.yarnrc.yml
 
 # ------------------------
 # 📝 Config / Env files

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,0 +1,2 @@
+yarnPath: .yarn/releases/yarn-4.9.2.cjs
+nodeLinker: node-modules


### PR DESCRIPTION
This PR implements the following changes:

- Migrates the project from PnP to `node_modules` to fix the `image-size` buffer issue.
- Updates the custom workflow to replace `--frozen-lockfile` with `--immutable`.
- Updates the remaining GitHub workflows to reflect the changes.