### PR TITLE
Update Tokenomics Parameters

### DIFF
--- a/docs/learn/dapp-staking/dapp-staking-protocol.md
+++ b/docs/learn/dapp-staking/dapp-staking-protocol.md
@@ -18,7 +18,7 @@ The following chapters will provide an overview of the functionality and termino
 
 Eras are the basic _time unit_ in dApp staking and their length is measured in the number of blocks.
 
-Eras are not expected to last long, e.g. current production networks era length is roughly 1 day (7200 blocks).
+Eras are not expected to last long, e.g. current production networks era length is roughly 1 day (14400 blocks).
 After an era ends, it's usually possible to claim rewards for it, if staker or dApp are eligible.
 
 ### Periods

--- a/docs/learn/dapp-staking/index.md
+++ b/docs/learn/dapp-staking/index.md
@@ -71,7 +71,7 @@ To understand how dApp staking v3 works, it’s essential to grasp the following
 
 #### Era
 
-`Eras` is a basic time unit in dApp Staking. The length of an Era is 7200 blocks, equivalent to roughly 1 day.
+`Eras` is a basic time unit in dApp Staking. The length of an Era is 14400 blocks, equivalent to roughly 1 day.
 
 #### Period & Subperiods
 
@@ -110,10 +110,10 @@ As an user or a dApp owner, you need to take the following parameters into consi
 
 | Parameters                     | Astar Network       | Shiden Network      | Shibuya             |
 | ------------------------------ | ------------------- | ------------------- | ------------------- |
-| Eras Per Period                | 122 (~122 days)     | 61 (~61 days)       | 28 (~7 days)        |
-| Eras Per Voting Subperiod      | 11 (~11 days)       | 6 (~6 days)         | 8 (~48 hours)       |
-| Eras Per Build&Earn Subperiod  | 111 (~111 days)     | 55 (~55 days)       | 20 (~120 hours)     |
-| Blocks Per Era                 | 7200 (~24 hours)    | 7200 (~24 hours)    | 1800 (~6 hours)     |
+| Eras Per Period                | 365 (~365 days)     | 183 (~183 days)     | 28 (~7 days)        |
+| Eras Per Voting Subperiod      | 1 (~1 day)          | 1 (~1 day)          | 1 (~6 hours)        |
+| Eras Per Build&Earn Subperiod  | 364 (~364 days)     | 182 (~182 days)     | 27 (~162 hours)     |
+| Blocks Per Era                 | 14400 (~24 hours)   | 14400 (~24 hours)   | 3600 (~6 hours)     |
 | Unlocking Period               | 9 Eras (~9 days)    | 4 Eras (~4 days)    | 4 Eras (~1 day)     |
 | Minimum Amount to Stake        | 500 ASTR            | 50 SDN              | 5 SBY               |
 
@@ -130,8 +130,6 @@ Tier System is a method to rank dApps based on the total value staked on them. T
 There are a limited number of tiers, each with a set number of slots and a minimum threshold for dApps to qualify. 
 
 A dApp must gain enough support to enter a tier, with thresholds defined as fixed percentages of total issuance. Higher tiers offer larger rewards.
-
-Within a tier, dApps can also have a **rank (0..10)**. Tokenomics 3.0 uses a deterministic `tier_rank_multipliers` weight model so a dApp's rewards can depend on **tier + rank** (not on empty slots). For the technical details and formulas, see the [technical overview](/docs/learn/dapp-staking/dapp-staking-protocol.md).
 
 Within a tier, dApps can also have a **rank (0..10)**. Tokenomics 3.0 uses a deterministic `tier_rank_multipliers` weight model so a dApp's rewards can depend on **tier + rank** (not on empty slots). For the technical details and formulas, see the [technical overview](/docs/learn/dapp-staking/dapp-staking-protocol.md).
 

--- a/docs/learn/tokenomics2/Inflation.md
+++ b/docs/learn/tokenomics2/Inflation.md
@@ -42,13 +42,13 @@ Each **period** is divided up into multiple **eras**.
 
 ### Example
 
-* Block is produced every 12 seconds
-* **Era length** is 7200 blocks which equals 24 hours (1 day) (This is _standard_ era length)
-* `Voting` subperiod length is 10 eras (This is the single _voting_ era which lasts 10 x 7700 blocks)
-* `Build&Earn` subperiod length is 81 eras
-* Cycle length is **4 periods**
+* Block is produced every 6 seconds
+* **Era length** is 14400 blocks which equals 24 hours (1 day) (This is _standard_ era length)
+* `Voting` subperiod length is 1 era (This is the single _voting_ era which lasts 1 x 14400 blocks)
+* `Build&Earn` subperiod length is 364 eras
+* Cycle length is **1 period**
 
-With such configuration, we'd end up with a cycle lasting 364 days (roughly a year), and each period taking around 3 months to complete.
+With such configuration, we'd end up with a cycle lasting 365 days (roughly a year), with a single period spanning the entire cycle.
 
 ## Recalculation
 
@@ -145,11 +145,11 @@ a single cycle.
 
 | Parameter                    | Astar | Shiden | Shibuya |
 |------------------------------|-------|--------|---------|
-| Periods Per Cycle            | 3     | 6      | 2       |
-| Eras Per Voting Subperiod    | 11    | 6      | 8       |
-| Eras Per Build&Earn Subperiod| 111    | 55     | 20      |
-| Blocks Per Era               | 7200 (~24 hours) | 7200 (~24 hours) | 1800 (~6 hours) |
-| Cycle Inflation Rate         | 7%    | 7%     | 1%      |
+| Periods Per Cycle            | 1     | 2      | 1       |
+| Eras Per Voting Subperiod    | 1     | 1      | 1       |
+| Eras Per Build&Earn Subperiod| 364   | 182    | 27      |
+| Blocks Per Era               | 14400 (~24 hours) | 14400 (~24 hours) | 3600 (~6 hours) |
+| Cycle Inflation Rate         | 5.5%  | 7%     | 1%      |
 | Treasury Part                | 5%    | 5%     | 5%      |
 | Collators Part               | 3.2%  | 3.2%   | 3%      |
 | dApps Part                   | 13%   | 13%    | 20%     |

--- a/docs/use/how-to-guides/layer-1/dapp-staking/for-stakers/move-staked-tokens/faqs.md
+++ b/docs/use/how-to-guides/layer-1/dapp-staking/for-stakers/move-staked-tokens/faqs.md
@@ -8,19 +8,19 @@ description: FAQs section related to the Move function
 Welcome to the **Move FAQs** section. Here you’ll find answers to the most common questions about how Move works in Astar dApp Staking.
 
 ## Q: How many safe moves do I get?
-A: 2 in each cycle. In the next cycle, it will refresh to allow 2 moves.
+A: There is no longer a move limit. Since Tokenomics 3.0 removed bonus rewards, the cap that previously restricted moves to 2 per cycle no longer applies. You can move your stake as many times as you want throughout the year without any penalty.
 
 ## Q: Does moving always cost a safe move?
-**A: Yes**, moving always consumes a safe move when done during **Build & Earn** and to **any registered dApp**.
+**A: No.** The safe move concept has been removed in Tokenomics 3.0. Moving your stake does not consume any allowance or affect your rewards in any way other than the era-level staking eligibility rule described below.
 
 ## Q: What if I split my move across 2 dApps?
-A: Each target counts as one move. If you move in total more than your allowance, bonus might be lost on last.
+A: Each target counts as one move operation, but there is no limit on how many moves you can perform. You can split and reallocate freely across as many dApps as you want.
 
 ## Q: Why did I lose my bonus?
-A: You went over the safe-move limit. If it’s still the same cycle, wait for next cycle and stake fresh to regain it.
+A: Bonus rewards no longer exist as of Tokenomics 3.0. If you are seeing references to bonuses in older tooling or interfaces, treat them as legacy content. There is no bonus pool or bonus APR to lose.
 
 ## Q: Do I still earn staking rewards in the era I Move my tokens?
 A: **No.** Since Move triggers an unstake followed by a stake, your tokens are considered *unstaked* during that era. As a result, **you won’t earn staking rewards for that era**.
 
 ## Q: What happens if I move from an unregistered dApp?
-A: When moving from an **unregistered dApp**, your **bonus is preserved** and the move **does not count** toward your safe move limit.
+A: When moving from an **unregistered dApp**, the move **does not affect your staking rewards** and operates the same as any other move. There is no bonus to preserve or move limit to track.

--- a/docs/use/how-to-guides/layer-1/dapp-staking/for-stakers/move-staked-tokens/index.md
+++ b/docs/use/how-to-guides/layer-1/dapp-staking/for-stakers/move-staked-tokens/index.md
@@ -4,10 +4,10 @@ Welcome to the **Move** section.
 
 In this part of the documentation, you'll find all the guidance you need to understand and use **Move**, a feature that allows you to:
 
-* Reallocate your already staked ASTR from one dApp to another without losing your bonus (as long as you're within your safe move limit);
+* Reallocate your already staked ASTR from one dApp to another freely, with no move limit or bonus mechanics to track;
 * Optimize your staking strategy based on performance, registration status, or market conditions;
-* Learn how staking rewards behave during move actions and how to avoid losing your bonus;
-* Combine stakes, handle partial unstakes, and manage bonus logic across dApps.
+* Learn how staking rewards behave during move actions and how to avoid missing rewards for the current era;
+* Combine stakes, handle partial unstakes, and manage your staking positions across dApps.
 
 This feature is part of the Astar dApp Staking experience and is especially powerful during the **Build & Earn** period.
 


### PR DESCRIPTION
**Pull Request Summary**

- [x] Update tokenomics and dApp staking parameters for runtime 2101 (Tokenomics 3.0)

Updated inflation parameters, era configuration, and staking documentation across multiple pages to reflect the runtime 2101 upgrade. 

Changes include corrected `blocks-per-era` values for Astar, Shiden, and Shibuya, updated cycle/period/era counts, reduced inflation ceiling from 7% to 5.5%, and removal of stale bonus reward and safe-move references.