### PR TITLE
fix: repair broken admonitions caused by Docusaurus 3.10.1 upgrade

### DIFF
--- a/docs/build/astar-beta-labs/metamask-snaps/index.md
+++ b/docs/build/astar-beta-labs/metamask-snaps/index.md
@@ -1,6 +1,6 @@
 # MetaMask Snaps
 
-:::danger Astar Snap Deprecation
+:::danger[Astar Snap Deprecation]
 
 **Astar Snap** will soon be deprecated and permanently disabled. This means any assets stored within the Snap will no longer be accessible through it.
 
@@ -17,7 +17,7 @@ To **avoid losing access to your funds**, we strongly recommend that you **migra
 👾 If you need help, feel free to reach out via our [**Discord community**](https://discord.gg/astarnetwork).
 
 :::
-:::tip Migrate your funds
+:::tip[Migrate your funds]
 
 To ensure your assets remain safe and accessible, please follow these simple steps to transfer your funds out of Astar Snap:
 
@@ -28,7 +28,7 @@ To ensure your assets remain safe and accessible, please follow these simple ste
 ✅ Your funds will now be safe in your new wallet.
 
 :::
-:::info Update your Astar Snap
+:::info[Update your Astar Snap]
 
 If you're not using Astar Snap version `0.9.1`, please [**update it here**](https://snaps.metamask.io/snap/npm/astar-network/snap/) before transferring your assets.
 

--- a/docs/build/dapp-staking/technical_solution.md
+++ b/docs/build/dapp-staking/technical_solution.md
@@ -152,7 +152,7 @@ Once we know the oldest period, we can use `PeriodEnd` storage map to find when 
 
 ### Bonus Rewards
 
-:::warning Attention
+:::warning[Attention]
 
 Tokenomics 3.0 has **no user-facing bonus rewards**, so indexers and UIs should not surface a "bonus pool", "bonus APR", or "vote-to-earn-bonus" guidance as a user benefit.
 

--- a/docs/build/environment/faucet.md
+++ b/docs/build/environment/faucet.md
@@ -16,12 +16,12 @@ In this guide, you’ll learn how to get some **SBY** tokens from the **Astar Po
 - A wallet that supports the **EVM** format (we’ll use Zerion)
 - An existing Astar EVM account
 
-:::tip Wallet Setup
+:::tip[Wallet Setup]
 
 To set up your wallet on Astar Network, follow → [**this guide**](/docs/use/get-started/index.md).
 
 :::
-:::info Astar & Shiden
+:::info[Astar & Shiden]
 
 This guide will also work for ASTR and SDN assets on Astar and Shiden networks.
 
@@ -49,7 +49,7 @@ Click on **Select wallet**.
 
 Choose the wallet you use, in this case, it will be **Zerion**, so we’ll click on **Metamask** to open the modal and connect it.
 
-:::info Metamask Mode
+:::info[Metamask Mode]
 
 Zerion uses a mode called Metamask mode, where every request made to Metamask is handled by Zerion first. That’s why we click on Metamask, as the Zerion logo doesn’t appear directly.
 

--- a/docs/build/nodes/archive-node/binary.md
+++ b/docs/build/nodes/archive-node/binary.md
@@ -244,4 +244,3 @@ sudo systemctl start astar.service
 ### Snapshot
 
 Please refer to the [**snapshot page**](/docs/build/nodes/snapshots).
-:::

--- a/docs/build/nodes/archive-node/docker.md
+++ b/docs/build/nodes/archive-node/docker.md
@@ -182,4 +182,3 @@ Then start a new container by following the instructions under the [Start Docker
 ### Snapshot
 
 Please refer to [**snapshot page**](/docs/build/nodes/snapshots/).
-:::

--- a/docs/learn/dapp-staking/dapp-staking-faq.md
+++ b/docs/learn/dapp-staking/dapp-staking-faq.md
@@ -8,7 +8,7 @@ import Figure from "/src/components/figure"
 
 ## General Info About Migration From V2 to V3
 
-:::note Historical Reference
+:::note[Historical Reference]
 dApp Staking V3 has been live since February 2024. The Tokenomics 3.0 revamp was activated in March 2026. The following is preserved for historical context only.
 :::
 
@@ -126,7 +126,7 @@ However, we recommend that you claim all your rewards and stake on a new project
 
 ### Q: What About Unclaimed Rewards from dApp Staking V2?
 
-:::note Historical Reference
+:::note[Historical Reference]
 dApp Staking V3 has been live since February 2024. The Tokenomics 3.0 revamp was activated in March 2026. The following is preserved for historical context only.
 :::
 
@@ -147,7 +147,7 @@ Please refer to [this Astar Forum discussion](https://forum.astar.network/t/dapp
 
 ### Q: What should you do to prepare for dApp Staking V3 migration?
 
-:::note Historical Reference
+:::note[Historical Reference]
 dApp Staking V3 has been live since February 2024. The Tokenomics 3.0 revamp was activated in March 2026. The following is preserved for historical context only.
 :::
 
@@ -202,7 +202,7 @@ In the event that a dApp is unregistered from dApp Staking, all developer unclai
 
 ### Q: We are a dApp participating in dAppStaking V2, What do we need to do?
 
-:::note Historical Reference
+:::note[Historical Reference]
 dApp Staking V3 has been live since February 2024. The Tokenomics 3.0 revamp was activated in March 2026. The following is preserved for historical context only.
 :::
 

--- a/docs/learn/dapp-staking/dapp-staking-protocol.md
+++ b/docs/learn/dapp-staking/dapp-staking-protocol.md
@@ -204,7 +204,7 @@ Key details about moving stake:
 - If the destination contract is newly staked, the user's total staked contracts must not exceed the maximum allowed number of staked contracts (same as the staking operation).
 - The destination contract must not be unregistered, but moving stake away from an unregistered contract is allowed.
 
-:::note Legacy/internal compatibility
+:::note[Legacy/internal compatibility]
 
 Older pallet versions may still contain bonus-eligibility and "safe move" bookkeeping for backward compatibility. Tokenomics 3.0 has **no user-facing bonus rewards**, and UIs should not promote or surface bonus mechanics as a user benefit.
 

--- a/docs/learn/interoperability/xcm/index.md
+++ b/docs/learn/interoperability/xcm/index.md
@@ -27,7 +27,7 @@ import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
 
 <DocCardList items={useCurrentSidebarCategory().items}/>
 
-:::note Further reading
+:::note[Further reading]
 
 - [The Astar Vision Part 1: Interoperability and Multi-chain dApps](https://medium.com/astar-network/the-astar-vision-part-1-interoperability-and-multi-chain-dapps-30f014087831)
 - [The Astar Vision Part 2: Asset Diversity Through XCM dApps and Smart Contracts](https://medium.com/astar-network/the-astar-vision-part-2-asset-diversity-through-xcm-dapps-and-smart-contracts-3a689dee5b77)

--- a/docs/learn/tokenomics2/index.md
+++ b/docs/learn/tokenomics2/index.md
@@ -3,7 +3,7 @@ sidebar_position: 12
 ---
 # Tokenomics 2.0
 
-:::note Historical Reference
+:::note[Historical Reference]
 Tokenomics 2.0 was superseded by [Tokenomics 3.0](/docs/learn/tokenomics3/) in March 2026. This page is kept as a historical reference.
 :::
 

--- a/docs/use/get-started/astar-substrate-wallet/wallet/fearless/index.md
+++ b/docs/use/get-started/astar-substrate-wallet/wallet/fearless/index.md
@@ -24,7 +24,7 @@ B. A browser extension on [**Chrome**](https://chromewebstore.google.com/detail/
 
 In this tutorial we will walk you through the mobile account creation process and the browser extension.
 
-:::info Import an account
+:::info[Import an account]
 
 You can also import an account using a [**passphrase (mnenomic)**](https://wiki.fearlesswallet.io/accounts/walkthrough/exporting-and-importing-a-wallet-using-a-passphrase) or [**JSON file**](https://wiki.fearlesswallet.io/accounts/walkthrough/exporting-and-importing-a-wallet-using-a-json-file).
 
@@ -40,7 +40,7 @@ If you're creating a new wallet, you'll be prompted to choose a name for your wa
 Right after that, you'll need to confirm your mnemonic passphrase by clicking on each word in the correct order:
 <Figure caption="" src={require('/docs/use/get-started/astar-substrate-wallet/wallet/fearless/images/fearless-image-2.png').default} width="100%" />
 
-:::warning Attention
+:::warning[Attention]
 
 Write down this phrase and store it in a safe place, as it can be used to restore your wallet if you ever lose access to it. If you lose this phrase, you won't be able to recover your wallet. Don't share this phrase with anyone.
 

--- a/docs/use/get-started/astar-substrate-wallet/wallet/talisman/index.md
+++ b/docs/use/get-started/astar-substrate-wallet/wallet/talisman/index.md
@@ -16,7 +16,7 @@ With the **Talisman browser extension**, you can securely store, send, and recei
 
 The extension is available on Chrome, Brave, Edge and Firefox. Download and install the Talisman extension from https://www.talisman.xyz.
 
-:::info Install tutorial
+:::info[Install tutorial]
 
 A download tutorial specific to your browser is also available → [**here**](https://docs.talisman.xyz/talisman/navigating-the-paraverse/account-management/download-the-extension).
 
@@ -151,7 +151,7 @@ You will be taken to [app.talisman.xyz/staking](http://app.talisman.xyz/staking)
 Enter the amount you’d like to stake (minimum staking amount is 500 Astr) and choose the dApp from the dropdown menu. Thereafter, click “Stake” after you’ve reviewed your transaction.
 <Figure caption="" src={require('/docs/use/get-started/astar-substrate-wallet/wallet/talisman/images/image-36.png').default} width="100%" />
 
-:::info Unbonding period
+:::info[Unbonding period]
 
 Please note: there is an unbonding period aprox of 9 days on Astar.
 

--- a/docs/use/how-to-guides/faq/tokenomics-3.0.md
+++ b/docs/use/how-to-guides/faq/tokenomics-3.0.md
@@ -49,7 +49,7 @@ A: The decay rate was calculated to achieve the target maximum supply of 10 bill
 
 When `r = 4 × 10⁻⁸`, the cumulative emission limit converges to `E₀ / r`, producing the 10 billion supply ceiling when added to current circulating supply.
 
-:::info Decay formula
+:::info[Decay formula]
 
 `E(n) = E₀ × (1 − 4×10⁻⁸)ⁿ` | Total future emissions: `lim C(n) = E₀ / r`
 
@@ -103,7 +103,7 @@ The theoretical maximum supply is 10 billion ASTR, representing the asymptotic c
 
 Significant burn events such as Burndrop reduce the effective maximum supply below the theoretical 10 billion ceiling. As a result, circulating supply and the theoretical cap will not converge exactly.
 
-:::info Live supply data
+:::info[Live supply data]
 
 Live supply data is available on the [Astar Network Explorer](https://astar.subscan.io). The 10B figure represents a mathematical ceiling. The effective maximum is lower due to ongoing burn activity.
 

--- a/docs/use/how-to-guides/layer-1/dapp-staking/for-devs/manage-dApp-Staking.md
+++ b/docs/use/how-to-guides/layer-1/dapp-staking/for-devs/manage-dApp-Staking.md
@@ -39,7 +39,7 @@ Click **Register now** to open the project information form.
 
 <Figure caption="Congrats banner with Register now button" src={require('/docs/use/how-to-guides/layer-1/dapp-staking/for-devs/img/developer-dashboard-1.png').default} width="100%" />
 
-:::info Not seeing the banner?
+:::info[Not seeing the banner?]
 
 Make sure you are connected with the **owner wallet** (the Substrate address that was used during the governance approval). The banner only appears for the registered owner address.
 
@@ -88,7 +88,7 @@ Navigate to **Stake** in the left sidebar. Your project should now appear in the
 
 <Figure caption="dApp rankings table with project listed" src={require('/docs/use/how-to-guides/layer-1/dapp-staking/for-devs/img/developer-dashboard-5.png').default} width="100%" />
 
-:::tip Public page
+:::tip[Public page]
 
 Click your project name in the rankings to open the public page that stakers see. Use this to verify all details look correct before promoting your listing.
 
@@ -118,7 +118,7 @@ Scroll down in the rewards table to see all pending periods and the **Total** cl
 
 Click **Claim your rewards** and sign the transaction. All pending rewards across all listed periods are released in a single transaction.
 
-:::info Reward accrual
+:::info[Reward accrual]
 
 dApp rewards are only earned while your project is in an active tier. A project must hold the required staking threshold (0.93% of total issuance for Tier 2, 0.35% for Tier 3) during the Build&Earn period to generate claimable dApp rewards.
 

--- a/docs/use/how-to-guides/layer-1/dapp-staking/for-stakers/how-to-stake.md
+++ b/docs/use/how-to-guides/layer-1/dapp-staking/for-stakers/how-to-stake.md
@@ -16,7 +16,7 @@ In this guide, you'll learn how to stake **ASTR** on Astar Network (L1) using th
 - Minimum of **500 ASTR** required to stake
 - A small amount of extra ASTR for transaction fees
 
-:::info Wallet Setup
+:::info[Wallet Setup]
 
 Don't have an Astar wallet yet? Follow → [**this guide**](/docs/use/get-started/index.md) to set one up on Astar Network.
 
@@ -24,7 +24,7 @@ Don't have an Astar wallet yet? Follow → [**this guide**](/docs/use/get-starte
 
 ## II. Step-by-step Guide
 
-:::warning dApp Staking Parameters
+:::warning[dApp Staking Parameters]
 
 Before staking, make sure you understand all the parameters described [**here**](/docs/learn/dapp-staking/#parameters).
 
@@ -49,7 +49,7 @@ A **Connect Native Wallet** modal will appear listing all supported Substrate wa
 
 <Figure caption="Connect Native Wallet modal, Talisman detected" src={require('/docs/use/how-to-guides/layer-1/dapp-staking/for-stakers/img/stake-astar/how-to-stake-3.png').default} width="100%" />
 
-:::tip Other Substrate Wallets
+:::tip[Other Substrate Wallets]
 
 Polkadot.js, SubWallet, and OneKey are also supported. The steps are the same for all of them.
 
@@ -79,7 +79,7 @@ The **Stake** page shows you a summary panel with your available balance, curren
 
 You can start staking by clicking **Start Staking** in the top panel, or by clicking **Stake** next to any dApp in the rankings table. Use the **Search dapps** bar to quickly find a specific project.
 
-:::tip Project Research
+:::tip[Project Research]
 
 Click on any project card for more details, team profiles, community links, and resources. You can also check [**DeFiLlama**](https://defillama.com/) or our [**Forum**](https://forum.astar.network/) for additional context.
 
@@ -87,7 +87,7 @@ Click on any project card for more details, team profiles, community links, and 
 
 ### 2.6. Step 6: Select a dApp and Enter the Amount
 
-:::note Maximum Supported dApps
+:::note[Maximum Supported dApps]
 
 You can support up to **16 projects** simultaneously from a single address.
 
@@ -97,7 +97,7 @@ Click **Stake** next to the dApp you want to support. You'll be taken to its sta
 
 <Figure caption="Enter staking amount for your chosen dApp" src={require('/docs/use/how-to-guides/layer-1/dapp-staking/for-stakers/img/stake-astar/how-to-stake-8.png').default} width="100%" />
 
-:::info Available Balance
+:::info[Available Balance]
 
 **Your available balance** includes tokens locked in governance. Make sure to keep some ASTR free for transaction fees.
 
@@ -111,7 +111,7 @@ Once the transaction is confirmed, go back to **Assets** and click **My Staking*
 
 <Figure caption="My Staking dashboard showing your active stake" src={require('/docs/use/how-to-guides/layer-1/dapp-staking/for-stakers/img/stake-astar/how-to-stake-9.png').default} width="100%" />
 
-:::info Token Unlock at Period End
+:::info[Token Unlock at Period End]
 
 At the end of each Period, tokens are automatically unstaked from all dApps. They remain **locked** on your account but must be **re-staked** for the new Period to keep earning rewards.
 
@@ -120,7 +120,7 @@ At the end of each Period, tokens are automatically unstaked from all dApps. The
 {/* Video temporarily hidden — recorded on old Portal version. Will be updated.
 ## Video Tutorial
 
-:::caution Outdated Video
+:::caution[Outdated Video]
 
 This video was recorded using an older version of the Astar Portal. An updated version will be available soon. For now, follow the written steps above.
 

--- a/docs/use/how-to-guides/layer-1/governance/extrinsic-calls.md
+++ b/docs/use/how-to-guides/layer-1/governance/extrinsic-calls.md
@@ -11,7 +11,7 @@ import Figure from "/src/components/figure"
 
 This document is the operational reference for **Community Council members** executing governance and treasury extrinsic calls on Astar Network. It covers five core areas: claiming Community Treasury rewards, executing Community Treasury staking operations, managing dApp Staking listings, and approving treasury spending proposals. Each section is structured around the two primary interfaces available for these operations: [**Polkadot.js Apps**](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Frpc.astar.network#/) and [**SubSquare**](https://astar.subsquare.io/community-council/motions).
 
-:::info Who is this guide for?
+:::info[Who is this guide for?]
 
 This guide is intended to serve as the primary reference point for ACC members or any authorized member performing operations on behalf of the Community Treasury and its resources.
 
@@ -28,7 +28,7 @@ Understanding the distinction between the **Astar Community Council (ACC)** and 
 
 ### II. Pre-Operation Checklist: When to Claim Rewards First
 
-:::warning Critical Requirement
+:::warning[Critical Requirement]
 
 Before executing **any operation that involves moving or repositioning stake held by the Community Treasury**, including staking, unstaking, and moving stake, **all pending Staker Rewards must be claimed first**. Failure to do so will result in failed transactions.
 
@@ -71,7 +71,7 @@ The Polkadot.js path allows any funded account to claim rewards on behalf of the
 YQnbw3oWxBju7z5CRVoq1K6JzwDaj6DNePwdc2R2fG7jdix
 ```
 
-:::info Good to Know
+:::info[Good to Know]
 
 Anyone can claim staking rewards on behalf of another account. Each single extrinsic call claims up to **16 eras of rewards** (~16 days). When the pending reward period spans multiple era pages, batch calls are required. Refer to [Section II.I.1.2](#12-understanding-era-pagination) for guidance on calculating how many calls are needed.
 
@@ -122,7 +122,7 @@ utility.batch(calls)
 
 <Figure caption="Claiming more than 16 pending eras" src={require('/docs/use/img/extrinsic-calls/acc-extrinsic-calls-3.png').default } width="100%" />
 
-:::tip Number of Calls Required
+:::tip[Number of Calls Required]
 
 The number of `claimStakerRewardsFor` calls needed depends on how many **era page boundaries** have been crossed since the last successful claim. See [Section II.I.1.2](#12-understanding-era-pagination) for the formula and worked examples.
 
@@ -169,7 +169,7 @@ page(era) = floor((era − 1) / 16) + 1
 | Two pages | 24 | 15 | 2 | 2 |
 | Three pages | 50 | 30 | 3 | 3 |
 
-:::tip Tip
+:::tip[Tip]
 
 As a general safeguard: **always include one extra `claimStakerRewardsFor` call** in your batch to handle edge cases at page boundaries.
 
@@ -200,7 +200,7 @@ Before submitting any treasury operation, verify the current claim status using 
 
 <Figure caption="Checking after claimed eras" src={require('/docs/use/img/extrinsic-calls/acc-extrinsic-calls-4.png').default } width="100%" />
 
-:::tip Recommended Workflow Before Any Treasury Operation
+:::tip[Recommended Workflow Before Any Treasury Operation]
 
 Before executing `stake`, `unstake`, or `moveStake` on behalf of the Community Treasury, always follow this sequence:
 
@@ -232,7 +232,7 @@ The Community Treasury is registered as a dApp in dApp Staking and earns **dApp 
 0x101b453a02f961b4e3f0526ecd4c533c3a80d795
 ```
 
-:::info No Motion Required
+:::info[No Motion Required]
 
 dApp Owner Rewards can be claimed by **any funded account**, council membership is not required. The transaction only needs sufficient ASTR for gas fees.
 
@@ -299,7 +299,7 @@ The script outputs:
 
 <Figure caption="Execute the motion to claim dApp Owner Rewards" src={require('/docs/use/img/extrinsic-calls/acc-extrinsic-calls-6.png').default } width="100%" />
 
-:::tip Adjusting the Era Scan Range
+:::tip[Adjusting the Era Scan Range]
 
 By default, the script scans the last **50 eras** (~50 days). You can increase `PAST_ERAS` to cover a longer period, for example setting it to **100** will scan the last 100 eras (~100 days).
 
@@ -347,7 +347,7 @@ The SubSquare path executes reward claims as a Community Council motion, providi
 3. Once the AYE threshold is reached, you can close the motion and the call **executes automatically onchain**.
 4. **Save and share the transaction hash in the ACC Telegram group.**
 
-:::info Threshold Calculation
+:::info[Threshold Calculation]
 
 For the standard **2/3 majority** requirement:
 - 3-member council → threshold = **2**
@@ -357,7 +357,7 @@ Always verify the current council composition before setting the threshold for a
 
 :::
 
-:::warning Call Construction for Treasury Operations
+:::warning[Call Construction for Treasury Operations]
 
 When executing operations that involve Community Treasury funds through a council motion, the call must be routed through `collectiveProxy → executeCall` to act on behalf of the treasury. The **"Community Proxy call"** Quick Start on SubSquare handles this automatically, do not bypass it.
 
@@ -369,7 +369,7 @@ When executing operations that involve Community Treasury funds through a counci
 
 The ACC manages part of the Community Treasury's ASTR holdings through dApp Staking, staking on approved dApps to support the ecosystem while generating staking yield for the treasury. These are governance operations that the ACC can execute on behalf of the Community Treasury, and they include staking on newly approved dApps, unstaking when necessary, and moving stake between dApps when conditions change. During the **annual voting period**, the ACC must re-stake on all active positions to renew them for the new cycle.
 
-:::warning Reward Claiming Requirement for Treasury Staking Operations
+:::warning[Reward Claiming Requirement for Treasury Staking Operations]
 
 Before executing any staking, unstaking, or stake-moving operation, **all pending Staker Rewards must be claimed**. During the annual voting period re-staking, **both Staker Rewards and dApp Owner Rewards must be fully claimed** before any staking transaction is submitted.
 
@@ -441,7 +441,7 @@ communityCouncil.propose(
 
 Use `moveStake` when repositioning stake from one dApp to another. Reward claiming calls can be batched alongside `moveStake` for efficiency.
 
-:::warning Claim Before Moving Stake
+:::warning[Claim Before Moving Stake]
 
 All staker rewards must be claimed before executing `moveStake`. While claim calls can be included in the same batch, executing them separately is recommended:
 
@@ -503,12 +503,12 @@ communityCouncil.propose(
 )
 ```
 
-:::info Important Note
+:::info[Important Note]
 
 This section assumes that the Community Treasury has its tokens locked in dApp Staking. If not, you must first execute the `dAppStaking.lock` function.
 
 :::
-:::tip Batch All Re-Stakes Into a Single Motion
+:::tip[Batch All Re-Stakes Into a Single Motion]
 
 Submitting all re-staking operations in one batched council motion minimizes the number of votes required from council members and reduces coordination overhead during the voting period.
 
@@ -569,12 +569,12 @@ The SubSquare path provides a guided interface for submitting treasury staking c
 8. Click **Submit**.
 9. **Save and share the transaction hash in the ACC Telegram group.**
 
-:::info Important Note
+:::info[Important Note]
 
 This section assumes that the Community Treasury has its tokens locked in dApp Staking. If not, you must first execute the `dAppStaking.lock` function.
 
 :::
-:::tip Council Voting Period
+:::tip[Council Voting Period]
 
 Once a motion is submitted, all ACC members must vote **Aye** within the designated voting period for it to execute automatically onchain. Coordinate the timing of the re-staking motion to align with the council's availability during the voting window.
 
@@ -586,7 +586,7 @@ Once a motion is submitted, all ACC members must vote **Aye** within the designa
 
 The ACC holds the authority to register new dApps in the Astar dApp Staking program and unregister dApps that no longer meet program requirements. Both operations are executed through council motions and carry different voting threshold requirements.
 
-:::info No Reward Claiming Required
+:::info[No Reward Claiming Required]
 
 dApp Staking management operations, registering and unregistering dApps, do **not** interact with the Community Treasury's staking balance. **No reward claiming is required** before proceeding with any operation in this section.
 
@@ -601,7 +601,7 @@ dApp Staking management operations, registering and unregistering dApps, do **no
 
 #### 1.1. Register a dApp
 
-:::info No collectiveProxy Needed
+:::info[No collectiveProxy Needed]
 
 Unlike treasury staking operations, registering a dApp does **not** require routing through `collectiveProxy → executeCall`. The call directly proposes `dappStaking → register` on behalf of the council.
 
@@ -630,7 +630,7 @@ communityCouncil.propose(
 
 #### 1.2. Unregister a dApp
 
-:::warning Higher Threshold Required
+:::warning[Higher Threshold Required]
 
 Unregistering a dApp requires a **4/5 majority** (e.g., 5 out of 6 council members). Ensure the threshold is set correctly before submitting the motion.
 
@@ -677,7 +677,7 @@ communityCouncil.propose(
 
 #### 2.2. Unregister a dApp
 
-:::warning Higher Threshold Required
+:::warning[Higher Threshold Required]
 
 Set the threshold to **4/5** of the current council size (e.g., 5 for a 6-member council).
 
@@ -686,7 +686,7 @@ Set the threshold to **4/5** of the current council size (e.g., 5 for a 6-member
 1. Navigate to [SubSquare Community Council → Motions](https://astar.subsquare.io/community-council/motions) and click **+ New Proposal**.
 2. Select **"Community Proxy call"** from the Quick Start options.
 
-:::info Why Community Proxy Call?
+:::info[Why Community Proxy Call?]
 
 There is no dedicated Quick Start option for dApp unregistration. Use **"Community Proxy call"** and manually select `dappStaking → unregister` in the call builder.
 
@@ -704,7 +704,7 @@ There is no dedicated Quick Start option for dApp unregistration. Use **"Communi
 
 The ACC reviews and votes on spending proposals submitted to the Community Treasury. Each proposal is processed through a council motion to either approve or reject the requested expenditure. Once the required threshold of AYE votes is reached, the outcome executes automatically onchain.
 
-:::info No Reward Claiming Required
+:::info[No Reward Claiming Required]
 
 Approving or rejecting treasury spending proposals is an administrative council action that does not involve moving staking positions. **No reward claiming is required** before proceeding.
 
@@ -777,7 +777,7 @@ SubSquare provides dedicated Quick Start options for treasury proposal approval 
 4. Set the **threshold** to 2/3 of the current council size.
 5. Enter the **Proposal ID**. The proposal name will auto-populate for verification.
 
-:::warning Verify Before Submitting
+:::warning[Verify Before Submitting]
 
 Always confirm the proposal name and details match the intended proposal before submitting the motion. Submitting an approval for the wrong proposal ID cannot be easily undone.
 
@@ -803,7 +803,7 @@ Always confirm the proposal name and details match the intended proposal before 
 5. Click **Submit**.
 6. **Save and share the transaction hash in the ACC Telegram group.**
 
-:::info Proposer Deposit on Rejection
+:::info[Proposer Deposit on Rejection]
 
 When a treasury spending proposal is rejected, the proposer's bond deposit is **slashed**. Ensure the rejection decision has been discussed and agreed upon by the full council before submitting the motion.
 

--- a/docs/use/how-to-guides/layer-1/governance/subsquare_guide.md
+++ b/docs/use/how-to-guides/layer-1/governance/subsquare_guide.md
@@ -15,7 +15,7 @@ The governance system ensures that decisions are made collectively and transpare
 
 This guide will walk you through the process of participating in Astar onchain governance using the **Subsquare** platform. For those who prefer the technical approach, you can refer to the [**Astar Governance Technical Guide**](/docs/learn/governance/technical_guide.md). For a comprehensive understanding of Astar governance structure and processes, we encourage you to read the [**Astar Governance Overview**](/docs/learn/governance/index.md) in our documentation.
 
-:::info Polkadot.js
+:::info[Polkadot.js]
 
 If you want to learn more about Polkadot.js, check out this [**Polkadot Official guide**](https://wiki.polkadot.com/general/polkadotjs-ui/).
 
@@ -35,7 +35,7 @@ Through **Subsquare**, you can:
 The purpose of this guide is to demonstrate how to utilize the **Subsquare** platform for governance actions on **Astar Network**.
 Working assumption is that the reader has familiarized themselves with the governance model, and will refer back to the docs if needed. This will be a **practical guide** for users.
 
-:::info Astar Subsquare
+:::info[Astar Subsquare]
 
 Check out the Subsquare version for [**Astar here**](https://astar.subsquare.io/) and get familiar with the existing proposals.
 
@@ -88,7 +88,7 @@ As you can see on the screen, you can either create the preimage, which is the f
 
 For the sake of this example, we will create a preimage of a `remarkWithEvent` extrinsic call, containing **LGM!** as the _message_.
 
-:::info Hash and Lenght
+:::info[Hash and Lenght]
 
 Please take note of the *hash* and *length*; these will be important for later use.
 
@@ -97,7 +97,7 @@ Submit the message and wait for the transaction to be confirmed and finalized.
 
 <Figure caption="Create a preimage - Part 3" src={require('/docs/use/img/17_Subsquare_preimage/preimage_3.png').default } width="100%" />
 
-:::info Treasury Spending
+:::info[Treasury Spending]
 
 If your intention is to request treasury funds through a Public Proposal, there are a few steps you must take before creating the preimage:
 
@@ -110,7 +110,7 @@ That’s it! With this preimage, you’ll be able to create a Public Proposal an
 :::
 Once the preimage has been created, it will be displayed on the main `Preimage` page.
 
-:::tip Understanding preimage deposits
+:::tip[Understanding preimage deposits]
 
 In the Astar onchain governance, preimage deposits are token amounts reserved when submitting a proposal’s preimage (**the encoded call data**) to the chain. They help prevent spam and cover onchain storage costs, ensuring the proposal’s details remain accessible throughout the governance process. 
 
@@ -121,7 +121,7 @@ These deposits are not spent but temporarily locked. They are refunded once the 
 :::
 <Figure caption="Create a preimage - Part 4" src={require('/docs/use/img/17_Subsquare_preimage/preimage_4.png').default } width="100%" />
 
-:::info Unnote button
+:::info[Unnote button]
 
 Note that the newly created image has an `Unnote` button. This is because the current user is the creator of the preimage.
 
@@ -142,7 +142,7 @@ Click on the `New Proposal` button to create a new `Public Proposal`. Since a pr
 
 The hash of the preimage is required to create a new proposal. In this case, hash of the preimage created earlier is simply copied and pasted into the `Preimage` field and the lengh will be automatically filled out.
 
-:::info Locked Balance
+:::info[Locked Balance]
 
 The `Locked Balance` refers to the amount being _deposited_ **(not locked)** for the proposal. In case the proposal is canceled, the deposit will be slashed. In case the proposal is tabled, the deposit will be refunded.
 
@@ -167,7 +167,7 @@ Proposals can be edited by clicking on the `Edit` button. Title and description 
 
 Clicking the `Second` button to support the proposal, increase its chances of being tabled and upgraded to a referendum. The user has to _match_ the deposit of the proposal, which is displayed on the page. It is possible to second a proposal multiple times.
 
-:::info Seconds
+:::info[Seconds]
 
 Any user, including the proposer, may support their proposal as many times as they wish. These **seconds** will be released once the proposal is **tabled** (upgraded to a referendum).
 
@@ -184,7 +184,7 @@ Clicking on the `New Proposal` button will allow the creation of a new spending 
 
 User needs to pick the `payout amount` & the `beneficiary`. The `Proposal bond` refers to the amount that needs to be deposited in order to create the proposal. 
 
-:::info Approve or Rejected
+:::info[Approve or Rejected]
 
 If the proposal is rejected, the bond will be `slashed`. Otherwise, the bond will be `refunded`.
 
@@ -197,12 +197,12 @@ After submitting the proposal, it will be displayed on the treasury page. The pr
 
 **Track #3: Community Treasury**
 
-:::info Community Treasury
+:::info[Community Treasury]
 
 The third track for creating onchain proposals is using the Community Treasury, which allows you to request spending, include/exclude dApps from dApp Staking, and execute other actions. To do this, you can reuse the same steps mentioned above.
 
 :::
-:::tip Community Council
+:::tip[Community Council]
 
 All proposals requesting actions or expenditures from the Community Treasury will be reviewed, approved, or rejected by the Community Council. More details on this below.
 
@@ -240,7 +240,7 @@ Clicking on the `+ Delegate` button allows you to delegate votes to another acco
 
 The `Target` is the account to which the votes are being delegated to. The `Balance` is the amount of native currency we're delegating. This is the amount that will be _locked_.
 
-:::info Delegating Votes
+:::info[Delegating Votes]
 
 The action of delegating voting power **DOES NOT** transfer the ownership of the tokens. They are merely _locked_ for normal use, but remain in the ownership of the delegator.
 
@@ -297,7 +297,7 @@ In case a user changes their mind, the vote can be removed by clicking on the `R
 
 <Figure caption="Voting - Part 5" src={require('/docs/use/img/21_Subsquare_voting/voting_5.png').default } width="100%" />
 
-:::tip Example Case
+:::tip[Example Case]
 
 This is an example of an account that is voting but has some votes delegated to it. In this particular situation, the account has:
 
@@ -337,7 +337,7 @@ The Community Council is entrusted with managing key ecosystem functions, includ
 * **Ecosystem Agent Tips:** Assessing and authorizing agent compensation requests.
 * **Governance Participation:** Acting as stewards of decentralized governance processes.
 
-:::tip Community Council Actions
+:::tip[Community Council Actions]
 
 The Council also holds specific onchain permissions to perform actions such as:
 
@@ -352,7 +352,7 @@ The Council also holds specific onchain permissions to perform actions such as:
 
 Through these responsibilities, the Community Council plays a critical role in maintaining the integrity, transparency, and sustainability of the Astar ecosystem.
 
-:::info Community Council Information
+:::info[Community Council Information]
 
 If you'd like to get more involved with the Community Council, check out our [**Forum post**](https://forum.astar.network/t/introducing-the-community-council/7588).
 
@@ -382,7 +382,7 @@ For this example, we will select the first option from the Quick Start: `Approve
 
 The proposal Id (can be checked under the Community Treasury tab) is required to create a new motion. Selecting an Id will display the proposal name, which also links to the proposal details.
 
-:::warning Important
+:::warning[Important]
 
 Community council members should ensure they're proposing and voting on the correct proposal.
 
@@ -403,12 +403,12 @@ In this case, one of the council members votes `Aye`.
 
 <Figure caption="Community Treasury Voting - Part 3" src={require('/docs/use/img/22_Subsquare_comm_treasury/comm_treasury_6.png').default } width="100%" />
 
-:::tip Remove Vote
+:::tip[Remove Vote]
 
 If a Council member wishes to remove their vote, they may do so as long as the proposal has not yet been `Executed`. The vote can be changed as many times as desired.
 
 :::
-:::info Reject a Proposal
+:::info[Reject a Proposal]
 
 The process to `Reject` a proposal is exactly the same, simply selecting `Reject a treasury proposal` when creating the `motion` during the step 1.
 
@@ -448,7 +448,7 @@ For this particular case, the threshold is set to 2/3 of the council members and
 The next is the call builder. When utilizing the community treasury, the call needs to start with `collectiveProxy → executeCall`.
 After that, the dApp staking call needs to be built.
 
-:::tip Batch Calls
+:::tip[Batch Calls]
 
 It's possible, and encouraged, to use the _batch_ calls to simplify the voting process.
 
@@ -542,17 +542,17 @@ The mechanism operates by specifying exact pallet names and function combination
 
 Select the `txPause` pallet and choose the `pause` function. Enter the exact pallet name as the first parameter, ensuring proper capitalization. Enter the specific function name as the second parameter using correct snake_case formatting.
 
-:::warning Good to know
+:::warning[Good to know]
 
 This action can be executed directly by the **Main Council** or **Technical Committee** through the [**Polkadot.js interface**](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Frpc.astar.network#/). However, it is not restricted to these bodies, an approved **governance referendum** can also authorize its execution.
 
 :::
-:::tip Example Case
+:::tip[Example Case]
 
 To pause balance transfers entirely, use `Balances` as the pallet name and `transfer_all` as the function name. To pause specific dApp staking claims, use `DappStaking` and `claim_unlocked` respectively.
 
 :::
-:::info Disable txPause
+:::info[Disable txPause]
 
 After the security threat is resolved and appropriate patches are implemented, create a new motion using the `txPause` pallet and `unpause` function with identical pallet and function name parameters to restore normal functionality.
 
@@ -567,19 +567,19 @@ Safe Mode initializes with a 12-hour active period and supports extension in 2-h
 
 Select the `safeMode` pallet and choose the `forceEnter` function. This extrinsic does not require additional parameters and will immediately activate comprehensive network protection upon successful vote completion.
 
-:::warning Good to know
+:::warning[Good to know]
 
 This action can be executed directly by the **Main Council** or **Technical Committee** through the [**Polkadot.js interface**](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Frpc.astar.network#/). However, it is not restricted to these bodies, an approved **governance referendum** can also authorize its execution.
 
 :::
-:::tip Manage Duration Extensions
+:::tip[Manage Duration Extensions]
 
 If additional time is required, create extension motions using the `safeMode` pallet and `forceExtend` function, specifying 2-hour increment extensions as needed.
 
 Multiple extensions are permitted for complex security incidents requiring extended resolution periods, though each extension requires separate council approval.
 
 :::
-:::info Exit Safe Mode
+:::info[Exit Safe Mode]
 
 Once security threats are fully resolved and network safety is confirmed, create a final motion using the `safeMode` pallet and `forceExit` function.
 

--- a/docs/use/how-to-guides/layer-1/governance/unstoppable-community-grant-program.md
+++ b/docs/use/how-to-guides/layer-1/governance/unstoppable-community-grant-program.md
@@ -91,7 +91,7 @@ Projects that pass Stage 1 are ranked by weighted KPI score as described above. 
 
 All allocations are executed as onchain motions by the ACC using Community Treasury funds. Positions can be tracked on the [Community Treasury account](https://astar.subscan.io/account/YQnbw3oWxBju7z5CRVoq1K6JzwDaj6DNePwdc2R2fG7jdix).
 
-:::note Parameter source
+:::note[Parameter source]
 All thresholds and caps on this page (floor triggers, position limits, combined exposure cap, KPI weights) were defined in the [SSP governance proposal](https://forum.astar.network/t/acc-strategic-staking-program/9439) approved by the Community Council. When the ACC updates any parameter, the forum record is the authoritative source.
 :::
 

--- a/docs/use/how-to-guides/soneium/dapp-staking/stake-on-soneium.md
+++ b/docs/use/how-to-guides/soneium/dapp-staking/stake-on-soneium.md
@@ -17,12 +17,12 @@ To complete this tutorial, you’ll need:
 - The **Soneium network** added to your wallet so you can view your funds
 - **ASTR** tokens on the Soneium network in your wallet
 
-:::info Wallet Setup
+:::info[Wallet Setup]
 
 To configure your wallet with the Soneium network, follow [**this guide**](https://docs.soneium.org/docs/users/wallets) from the official docs.
 
 :::
-:::tip Get ASTR tokens
+:::tip[Get ASTR tokens]
 
 If you want to acquire ASTR tokens on the Soneium using your local currency, use [**Alchemy Pay**](https://ramp.alchemypay.org/#/index).
 
@@ -38,7 +38,7 @@ This guide assumes you already:
 
 We’ll now walk through the full transfer process step by step.
 
-:::caution Disclaimer
+:::caution[Disclaimer]
 
 Astake is independent projects and is **not affiliated with or operated by Astar Foundation**. Users are strongly advised to **conduct their own research** and contact the respective project teams for more information **before interacting with these dApps**. The Astar Foundation **disclaims all responsibility** for any issues, losses, or risks that may arise from the use of third-party projects.
 
@@ -60,7 +60,7 @@ Astake is independent projects and is **not affiliated with or operated by Astar
 
 - **Secure, DeFi-Ready & Easy to Use:** Audited by PeckShield and designed with user experience in mind, Astake provides a secure and intuitive interface. wstASTR is supported by DeFi protocols like Sake, Kyo, and SoneX to unlock extra yield.
 
-:::tip Astake docs
+:::tip[Astake docs]
 
 If you want to learn more about Astake, explore their official documentation [**here**](https://astakes-organization.gitbook.io/doc).
 

--- a/docs/use/how-to-guides/soneium/transfer-tokens/from-astar-to-soneium.md
+++ b/docs/use/how-to-guides/soneium/transfer-tokens/from-astar-to-soneium.md
@@ -15,12 +15,12 @@ In this guide, you’ll learn how to transfer **ASTR** tokens from **Astar Netwo
 - A wallet that supports the **EVM** format (we’ll use Zerion)
 - ASTR tokens in your Substrate wallet on Astar L1
 
-:::info Wallet Setup
+:::info[Wallet Setup]
 
 To set up your wallet on Astar Network, follow → [**this guide**](/docs/use/get-started/index.md), and use → [**this one**](https://docs.soneium.org/docs/users/wallets) for Soneium.
 
 :::
-:::tip Get ASTR tokens
+:::tip[Get ASTR tokens]
 
 To acquire ASTR tokens through a DEX or CEX, follow [**this guides**](/docs/use/how-to-guides/layer-1/get-astr-token/index.md) in our documentation.
 
@@ -90,7 +90,7 @@ Go to the **wallet** button and click it.
 
 Choose the wallet you use, in this case, it will be **Zerion**, so we’ll click on **Metamask** to open the modal and connect it.
 
-:::info Metamask Mode
+:::info[Metamask Mode]
 
 Zerion uses a mode called Metamask mode, where every request made to Metamask is handled by Zerion first. That’s why we click on Metamask, as the Zerion logo doesn’t appear directly.
 
@@ -110,7 +110,7 @@ Go to the **Bridge to Soneium** section by clicking the button.
 
 Once you’re on the bridge page, you’ll see that the transaction is set to go from **Astar EVM** to **Soneium**. Enter the amount you want to send, approve the transaction by clicking the **Approve** button, and finally, initiate the bridge.
 
-:::info Fee costs
+:::info[Fee costs]
 
 Pay close attention to the bridge fee and the time the transaction usually takes.
 

--- a/docs/use/how-to-guides/soneium/transfer-tokens/from-ethereum-to-soneium.md
+++ b/docs/use/how-to-guides/soneium/transfer-tokens/from-ethereum-to-soneium.md
@@ -23,7 +23,7 @@ Before you begin, ensure you have:
 - **ETH** for gas fees on the source chain.
 - Tokens in your wallet on **Ethereum** or another supported **L2** (Arbitrum, Base, OP Mainnet, etc.).
 
-:::info Wallet Setup
+:::info[Wallet Setup]
 
 Need help setting up your wallet on **Soneium**? Follow this [**wallet guide**](https://docs.soneium.org/docs/users/wallets) from Soneiun's documentation.
 
@@ -95,12 +95,12 @@ Need help setting up your wallet on **Soneium**? Follow this [**wallet guide**](
 5. Choose token (e.g., ETH)
 6. Approve and confirm the transaction
 
-:::info Final tip
+:::info[Final tip]
 
 Whether you’re moving funds to explore Soneium dApps or participate in a campaign, these tools will help you move assets safely and efficiently into the Soneium ecosystem. 
 
 :::
-:::tip Astar support
+:::tip[Astar support]
 
 Feel free to ask your questions in our [**official Astar Discord**](https://discord.com/invite/AstarNetwork).
 

--- a/docs/use/how-to-guides/soneium/transfer-tokens/from-soneium-to-astar.md
+++ b/docs/use/how-to-guides/soneium/transfer-tokens/from-soneium-to-astar.md
@@ -15,12 +15,12 @@ In this guide, you’ll learn how to transfer **ASTR** tokens from **Soneium (L2
 - A wallet that supports the **EVM** format (we’ll use Zerion)
 - ASTR tokens in your EVM wallet on Soneium
 
-:::info Wallet Setup
+:::info[Wallet Setup]
 
 To set up your wallet on Soneium, follow → [**this guide**](https://docs.soneium.org/docs/users/wallets), and use → [**this one**](/docs/use/get-started/index.md) for Astar Network.
 
 :::
-:::tip Get ASTR tokens
+:::tip[Get ASTR tokens]
 
 If you want to acquire ASTR tokens on the Soneium using your local currency, use [**Alchemy Pay**](https://ramp.alchemypay.org/#/index).
 
@@ -54,7 +54,7 @@ Click on **Select wallet**.
 
 Choose the wallet you use, in this case, it will be **Zerion**, so we’ll click on **Metamask** to open the modal and connect it.
 
-:::info Metamask Mode
+:::info[Metamask Mode]
 
 Zerion uses a mode called Metamask mode, where every request made to Metamask is handled by Zerion first. That’s why we click on Metamask, as the Zerion logo doesn’t appear directly.
 
@@ -82,7 +82,7 @@ Once we switch the network, a message will appear in our wallet confirming the c
 
 Enter the amount you want to transfer and click the **Approve** button to sign the permission and enable the bridge.
 
-:::info Max Amount
+:::info[Max Amount]
 
 If you want to send your entire balance, check the **Approve Max Amount** box.
 
@@ -94,7 +94,7 @@ If you want to send your entire balance, check the **Approve Max Amount** box.
 
 Once you’ve signed the **Approve** transaction, the **Bridge** button will be enabled, allowing you to send your ASTR tokens from **Soneium** to **Astar EVM**.
 
-:::info Fee costs
+:::info[Fee costs]
 
 Pay close attention to the bridge fee and the time the transaction usually takes.
 


### PR DESCRIPTION
## Summary

The Docusaurus 3.10.1 upgrade (#793) pulled in a newer `mdast-util-directive`/`micromark-extension-directive`. It enforces the strict directive spec: admonition titles must use bracket syntax, `:::info[Title]`. The old freeform syntax `:::info Title` is no longer recognized as a directive at all, so it silently rendered as literal paragraph text instead of a styled callout (as reported by Guenael on the [Subsquare governance guide](https://docs.astar.network/docs/use/how-to-guides/layer-1/governance/subsquare_guide)).

- Converted all freeform-title admonitions (`:::type Title` -> `:::type[Title]`) across the repo: 25 in `subsquare_guide.md`, 72 more across 18 other files.
- Removed two unrelated orphaned closing `:::` fences (pre-existing since 2022/2023, unrelated to the dependency bump) in `binary.md` and `docker.md` that were also rendering as stray literal text.