### PR TITLE
docs: fix malformed SubQuery Academy link (missing `.network`)

### DIFF
--- a/docs/build/integrations/indexers/subquery.md
+++ b/docs/build/integrations/indexers/subquery.md
@@ -12,7 +12,7 @@ SubQuery's superior indexing capabilities support Astar native, EVM and WASM-bas
 
 Another one of SubQuery's competitive advantages is the ability to aggregate data not only within a chain but across blockchains all within a single project. This allows the creation of feature-rich dashboard analytics or multi-chain block scanners.
 
-Other advantages include superior performance with multiple RPC endpoint configurations, multi-worker capabilities and a configurable caching architecture. To find out more, visit our [documentation](https://academy.subquery).
+Other advantages include superior performance with multiple RPC endpoint configurations, multi-worker capabilities and a configurable caching architecture. To find out more, visit our [documentation](https://academy.subquery.network/).
 
 ## Prerequisites
 


### PR DESCRIPTION
## Problem

`docs/build/integrations/indexers/subquery.md:15` links to `https://academy.subquery` — the `.network` TLD is missing, so the hostname does not resolve to the docs site (it returns 502).

Every other SubQuery link in the very same file uses the full host, including line 357 which points at `https://academy.subquery.network/`, so this is clearly a typo rather than an intentional shorthand.

It is also the "To find out more, visit our documentation" link in the intro paragraph — the first thing a reader clicks on that page.

## Fix

`https://academy.subquery` → `https://academy.subquery.network/`

## Verification

Broken URL returns 502 on two separate checks; the replacement returns 200 on two separate checks.

Worth noting for the link-checking setup: the automated checker does not flag this one because the host answers with 502 rather than 404, so a status-code filter that only looks for 404 will keep missing malformed hostnames like this.